### PR TITLE
fix(ci): replace broken vexctl list with jq-based VEX validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,8 +307,9 @@ jobs:
           echo "Extracted VEX document:"
           jq '.' extracted-vex.json
 
-          echo "=== 4. vexctl: validate VEX document structure ==="
-          vexctl list extracted-vex.json
+          echo "=== 4. Validate VEX document structure ==="
+          jq -e '.["@context"] and .statements' extracted-vex.json > /dev/null
+          echo "VEX document has valid OpenVEX structure (context + statements present)"
 
           echo "=== 5. Trivy: scan with VEX from OCI attestation ==="
           trivy image --vex oci --format table "${IMAGE}@${PLATFORM_DIGEST}" || true


### PR DESCRIPTION
## Summary

The release workflow's VEX validation step was failing because `vexctl list` only lists valid enum values (status/justification) — it cannot validate a VEX document file. The command `vexctl list extracted-vex.json` treated the filename as an invalid subcommand.

Replaced with a `jq -e` check that verifies the extracted VEX document has the required OpenVEX fields (`@context` and `statements`).

## Test plan
- [ ] Trigger a release and verify the VEX validation step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)