### PR TITLE
fix(ci): bump Go 1.25.7 → 1.25.8 to fix vulncheck failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Verify and download dependencies
         run: go mod download && go mod verify
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Run go vet
         run: go vet ./...
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Verify dependencies
         run: go mod download && go mod verify
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Verify dependencies
         run: go mod download && go mod verify
@@ -138,7 +138,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@c56c2d3e59e4281cc41dea2217323ba5694b171e # v3.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY web/ ./
 RUN npm run build
 
 # Go build stage
-FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hkolvenbach/oci-explorer
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/google/go-containerregistry v0.20.7


### PR DESCRIPTION
## Summary
- Bumps Go from 1.25.7 to 1.25.8 across go.mod, Dockerfile, ci.yml, and release.yml
- Fixes 3 Go stdlib CVEs that cause `govulncheck` CI to fail on all PRs:
  - **CVE-2026-25679** (`net/url`): incorrect IPv6 host literal parsing
  - **CVE-2026-27139** (`os`): ReadDir FileInfo escapes from Root on Unix
  - **CVE-2026-27142** (`html/template`): unescaped URLs in meta content attribute (XSS)

## Test plan
- [ ] CI vulncheck job passes (was failing on all recent PRs)
- [ ] `go mod tidy` produces no diff
- [ ] Docker build succeeds with `golang:1.25.8-alpine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)