### PR TITLE
fix(ci): correct flyctl-actions SHA for Fly.io deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,7 +344,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3571571e1b0adc3 # v1.5
+      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # v1.5
 
       - name: Deploy to Fly.io
         run: flyctl deploy --image ghcr.io/${{ github.repository }}:${{ needs.version.outputs.version }}


### PR DESCRIPTION
## Summary

- Fixed incorrect pinned SHA for `superfly/flyctl-actions/setup-flyctl` that caused the deploy job to 404

## Test plan

- [ ] Release workflow `deploy-fly` job resolves the action successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)