### PR TITLE
docs: ociexplorer.dev link + allow dependabot for Claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "dependabot[bot]"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # OCI Image Explorer
 
-A local Go application that visualizes OCI container image structures including layers, manifests, referrers, SBOMs, attestations, and other supply chain artifacts.
+Visualize OCI container image structures including layers, manifests, referrers, SBOMs, attestations, and other supply chain artifacts. Built with Go and Svelte.
 
 ![OCI Image Explorer](https://img.shields.io/badge/OCI-1.1-blue) ![Go](https://img.shields.io/badge/Go-1.25+-00ADD8) ![Svelte](https://img.shields.io/badge/Svelte-5-FF3E00) ![Trivy](https://img.shields.io/badge/Trivy-0.69+-1904DA) ![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
 
-**[Try it live at ociexplorer.dev](https://ociexplorer.dev)** — no install needed. Or [run it locally](#quick-start) for private registries and vulnerability scanning.
+---
+
+<h3><img src="web/public/favicon.svg" width="22" height="22" align="absmiddle" alt="logo" />&nbsp; Try it live at <a href="https://ociexplorer.dev">ociexplorer.dev</a></h3>
+
+<sub>You can also [run it locally](#quick-start) for private registries and vulnerability scanning.</sub>
+
+---
 
 ## Features
 


### PR DESCRIPTION
## Summary

- **README**: Add prominent "Try it live at ociexplorer.dev" link at the top, with a hint to run locally for private registries
- **Claude workflow**: Add `dependabot[bot]` to `allowed_bots` so Dependabot PRs can trigger the Claude Code action

## Test plan

- [ ] README renders correctly with the live link
- [ ] Dependabot PRs no longer fail the Claude Code action

🤖 Generated with [Claude Code](https://claude.com/claude-code)