### PR TITLE
fix(ci): deploy-fly missing version job dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,7 +335,7 @@ jobs:
 
   deploy-fly:
     runs-on: ubuntu-latest
-    needs: [release-docker]
+    needs: [version, release-docker]
     if: inputs.dry-run != true
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Added `version` to `deploy-fly.needs` so `needs.version.outputs.version` resolves correctly instead of being empty (which produced `ghcr.io/hkolvenbach/oci-explorer:` with no tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)