### PR TITLE
fix(web): resolve state management issues across image navigation

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { appState, buildPlatformDigestMap, getFilteredReferrers, getSelectedPlatformConfig, getSelectedPlatformName } from './lib/state.svelte';
   import type { MatchingTagsResult } from './lib/types';
   import * as api from './lib/api';
@@ -28,11 +29,16 @@
     }).catch(() => {});
   });
 
+  // Synchronously initialise searchQuery from URL before first render
+  // so the search bar never flashes the default placeholder.
+  const initialQ = new URLSearchParams(window.location.search).get('q');
+  if (initialQ) appState.searchQuery = initialQ;
+
   function loadFromURL() {
     const q = new URLSearchParams(window.location.search).get('q');
     if (q) {
       appState.searchQuery = q;
-      doInspect(true);
+      doInspect(q);
     } else {
       appState.searchQuery = 'alpine:latest';
       appState.currentData = null;
@@ -40,22 +46,33 @@
     }
   }
 
-  // Read ?q= from URL on mount
-  $effect(() => { loadFromURL(); });
+  // Trigger the initial fetch after mount. onMount (not $effect) because this
+  // is a one-time side-effect — no reactive dependencies should be tracked.
+  onMount(() => {
+    if (initialQ) doInspect(initialQ);
+  });
 
-  async function doInspect(skipURLUpdate = false) {
-    const imageRef = appState.searchQuery.trim();
+  let inspectGeneration = 0;
+
+  async function doInspect(imageRefOverride?: string) {
+    const imageRef = (imageRefOverride ?? appState.searchQuery).trim();
     if (!imageRef) return;
+    if (imageRefOverride) appState.searchQuery = imageRef;
+
+    const gen = ++inspectGeneration;
+    const skipURLUpdate = !!imageRefOverride;
 
     appState.selectedPlatform = 'all';
     appState.platformDigestMap = {};
     appState.collapseStates = {};
+    appState.viewToggles = { config: false, annotations: false, imageIndex: false };
     appState.isLoading = true;
     appState.error = '';
     matchingTags = null;
 
     try {
       const data = await api.inspectImage(imageRef);
+      if (gen !== inspectGeneration) return;
       appState.currentData = data;
       buildPlatformDigestMap(data);
       if (!skipURLUpdate) {
@@ -63,21 +80,22 @@
         url.searchParams.set('q', imageRef);
         history.pushState({ image: imageRef }, '', url.toString());
       }
-      // Fetch matching tags in background (non-blocking)
       api.fetchMatchingTags(imageRef).then((result) => {
+        if (gen !== inspectGeneration) return;
         matchingTags = result;
       }).catch(() => {});
     } catch (err) {
+      if (gen !== inspectGeneration) return;
       appState.error = (err as Error).message;
       appState.currentData = null;
     } finally {
-      appState.isLoading = false;
+      if (gen === inspectGeneration) appState.isLoading = false;
     }
   }
 
   function quickInspect(image: string) {
     appState.searchQuery = image;
-    doInspect();
+    doInspect(image);
   }
 
   let hasMultiplePlatforms = $derived(Object.keys(appState.platformDigestMap).length > 1);
@@ -102,41 +120,43 @@
 
     <div class="relative">
       {#if appState.currentData}
-        {#if appState.currentView === 'graph'}
-          <GraphView data={appState.currentData} />
-        {:else}
-          <ImageSummary data={appState.currentData} />
+        {#key appState.currentData.digest}
+          {#if appState.currentView === 'graph'}
+            <GraphView data={appState.currentData} />
+          {:else}
+            <ImageSummary data={appState.currentData} />
 
-          <ScanSection data={appState.currentData} />
+            <ScanSection data={appState.currentData} />
 
-          {#if hasMultiplePlatforms}
-            <PlatformFilter data={appState.currentData} />
+            {#if hasMultiplePlatforms}
+              <PlatformFilter data={appState.currentData} />
+            {/if}
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <!-- Left Column -->
+              <div>
+                {#if appState.currentData.imageIndex}
+                  <ImageIndexSection imageIndex={appState.currentData.imageIndex} />
+                {/if}
+                <ReferrersSection referrers={filteredReferrers} totalCount={appState.currentData.referrers?.length || 0} />
+                {#if appState.currentData.manifest?.annotations}
+                  <AnnotationsSection annotations={appState.currentData.manifest.annotations} />
+                {/if}
+              </div>
+
+              <!-- Right Column -->
+              <div>
+                {#if selectedConfig}
+                  <ConfigSection config={selectedConfig} platformName={selectedPlatformName} />
+                {/if}
+                {#if appState.currentData.manifest}
+                  <LayersSection layers={appState.currentData.manifest.layers} />
+                {/if}
+                <TagsSection tags={appState.currentData.tags || []} {matchingTags} oninspect={quickInspect} />
+              </div>
+            </div>
           {/if}
-
-          <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <!-- Left Column -->
-            <div>
-              {#if appState.currentData.imageIndex}
-                <ImageIndexSection imageIndex={appState.currentData.imageIndex} />
-              {/if}
-              <ReferrersSection referrers={filteredReferrers} totalCount={appState.currentData.referrers?.length || 0} />
-              {#if appState.currentData.manifest?.annotations}
-                <AnnotationsSection annotations={appState.currentData.manifest.annotations} />
-              {/if}
-            </div>
-
-            <!-- Right Column -->
-            <div>
-              {#if selectedConfig}
-                <ConfigSection config={selectedConfig} platformName={selectedPlatformName} />
-              {/if}
-              {#if appState.currentData.manifest}
-                <LayersSection layers={appState.currentData.manifest.layers} />
-              {/if}
-              <TagsSection tags={appState.currentData.tags || []} {matchingTags} oninspect={quickInspect} />
-            </div>
-          </div>
-        {/if}
+        {/key}
       {/if}
 
       <LoadingOverlay visible={appState.isLoading} />

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -12,7 +12,7 @@
 <header class="bg-slate-800 border-b border-slate-700 sticky top-0 z-10">
   <div class="max-w-7xl mx-auto px-4 py-4">
     <div class="flex items-center justify-between flex-wrap gap-4">
-      <a href="/" class="flex items-center gap-3 hover:opacity-80 transition-opacity" onclick={(e) => { e.preventDefault(); appState.currentData = null; appState.error = ''; appState.searchQuery = 'alpine:latest'; history.pushState(null, '', '/'); }}>
+      <a href="/" class="flex items-center gap-3 hover:opacity-80 transition-opacity" onclick={(e) => { e.preventDefault(); appState.currentData = null; appState.error = ''; appState.searchQuery = 'alpine:latest'; appState.currentView = 'details'; appState.viewToggles = { config: false, annotations: false, imageIndex: false }; history.pushState(null, '', '/'); }}>
         <div class="w-10 h-10 rounded-md bg-orange-500 flex items-center justify-center">
           <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"></path>


### PR DESCRIPTION
## Summary

- **URL/SearchBar desync**: Replace `$effect` with `onMount` for URL initialization — correct Svelte 5 primitive that doesn't track reactive dependencies
- **Stale data between images**: Wrap detail/graph views in `{#key appState.currentData.digest}` so all child components remount with fresh state on image change
- **Race condition**: Generation counter discards responses from superseded API calls
- **Home click state leak**: Reset `currentView` to `details` and clear `viewToggles` when clicking the logo
- **Loading UX preserved**: Old content stays visible behind the loading overlay (no layout collapse from nulling `currentData`)

## Approach

Uses idiomatic Svelte 5 patterns instead of manual state resets:
- `onMount` for one-time URL initialization (not `$effect`)
- `{#key}` block for structural component reset (not imperative state clearing)
- ScanSection unchanged — `{#key}` handles remounting automatically

## Test plan

- [ ] Load app with `?q=alpine` in URL — search bar shows "alpine", results load
- [ ] Type a new image ref — URL updates, results change, no stale data visible
- [ ] Click browser back/forward — correct image loads each time
- [ ] Navigate between images rapidly — no stale results appear
- [ ] Click logo — returns to welcome view (not graph view)
- [ ] Switch to graph view, inspect new image — view resets to details
- [ ] Scan results don't persist when navigating between images

🤖 Generated with [Claude Code](https://claude.com/claude-code)