### PR TITLE
perf(scan): speed up Trivy scanning and improve observability

### DIFF
--- a/docs/adrs/003-osv-vulnerability-lookup.md
+++ b/docs/adrs/003-osv-vulnerability-lookup.md
@@ -1,0 +1,168 @@
+# ADR-003: SBOM-Based Vulnerability Lookup via OSV.dev
+
+- **Status:** Proposed
+- **Date:** 2026-03-28
+
+## Context
+
+Vulnerability scanning currently runs Trivy as a subprocess (`trivy image --format json --scanners vuln <ref>`). This works but has several costs on the hosted Fly.io instance:
+
+1. **Image pull** -- Trivy downloads image layers to extract packages. Large images (1 GB+) take 1-2 minutes on a 512 MB / 1 CPU machine.
+2. **DB download** -- Trivy maintains a ~50 MB vulnerability database that must be fetched on cold start and refreshed daily.
+3. **Memory pressure** -- Trivy peak RSS can exceed 300 MB on large images, competing with the Go server on a 512 MB machine.
+4. **Concurrency** -- only one Trivy process can run at a time (semaphore) to avoid OOM, so scan requests queue.
+
+Many OCI images already publish SBOMs as OCI referrers (SPDX or CycloneDX). The app already discovers and fetches these SBOMs (`/api/sbom`). This represents an unused shortcut: if the package list is already available, we don't need Trivy to extract it again.
+
+## Decision Drivers
+
+- Reduce scan latency from minutes to seconds for images with SBOMs
+- Eliminate Trivy subprocess resource pressure
+- Maintain vulnerability coverage quality
+- Graceful fallback for images without SBOMs
+- No additional infrastructure to operate
+
+## Decision
+
+Add an alternative vulnerability lookup path that uses **SBOM referrers + the OSV.dev batch API** when an SBOM is available, falling back to Trivy when it is not.
+
+### Flow
+
+```
+User clicks "Scan"
+    |
+    v
+Does the image have SBOM referrers?
+    |                    |
+   yes                  no
+    |                    |
+    v                    v
+Fetch SBOM         Run Trivy (current path)
+    |
+    v
+Extract packages (name, version, ecosystem)
+    |
+    v
+POST /v1/querybatch to api.osv.dev
+    |
+    v
+Map OSV results -> ScanResult
+```
+
+### OSV.dev Batch API
+
+```
+POST https://api.osv.dev/v1/querybatch
+{
+  "queries": [
+    { "package": { "name": "openssl", "ecosystem": "Debian:12" }, "version": "3.0.11-1" },
+    { "package": { "name": "golang.org/x/net", "ecosystem": "Go" }, "version": "0.17.0" },
+    ...
+  ]
+}
+```
+
+- Free, no API key required
+- Rate limit: 500 queries per minute (batch counts as 1 query regardless of size)
+- Max 1000 packages per batch request
+- Response includes CVE IDs, severity, fixed versions, references
+
+### SBOM Package Extraction
+
+Map SBOM package types to OSV ecosystems:
+
+| SBOM source | OSV ecosystem |
+|---|---|
+| `apk` (Alpine) | `Alpine:v3.x` |
+| `deb` (Debian/Ubuntu) | `Debian:12` / `Ubuntu:24.04` |
+| `rpm` (RHEL/Fedora) | `Red Hat` |
+| `go` (Go modules) | `Go` |
+| `npm` | `npm` |
+| `pypi` | `PyPI` |
+| `cargo` | `crates.io` |
+
+### Result Mapping
+
+OSV responses map to the existing `VulnSummary` struct:
+
+| OSV field | VulnSummary field |
+|---|---|
+| `id` | `vulnerabilityID` |
+| `summary` | `title` |
+| `details` | `description` |
+| `affected[].package.name` | `pkgName` |
+| `affected[].ranges[].fixed` | `fixedVersion` |
+| `severity[].score` (CVSS) | `cvssScore` |
+| `references[].url` | `references` |
+| `database_specific.severity` | `severity` |
+
+### Cache Integration
+
+OSV results use the same S3 cache as Trivy results, keyed by `scan/{digest}`. The frontend doesn't need to know which backend produced the result.
+
+## Alternatives Considered
+
+### 1. Trivy as a Go library
+
+Trivy's core scanning logic (`github.com/aquasecurity/trivy`) can be imported as a Go library instead of shelling out.
+
+- **Pro:** No subprocess overhead, shared memory space
+- **Con:** Massive dependency tree (~500 transitive deps), pins us to Trivy's release cycle, still needs image layer download and vulnerability DB
+
+Rejected: dependency weight and image pull requirement remain.
+
+### 2. Grype (Anchore) as a Go library
+
+Similar to Trivy but with a cleaner library API.
+
+- **Pro:** Better Go library support than Trivy
+- **Con:** Same fundamental problem -- needs image layers and its own vulnerability DB
+
+Rejected: same resource constraints as Trivy.
+
+### 3. Run Trivy as a sidecar / server mode
+
+Run `trivy server` as a persistent process, query it via HTTP.
+
+- **Pro:** DB loaded once, amortized across scans
+- **Con:** Doubles memory usage (server + app), complex lifecycle management on distroless
+
+Rejected: 512 MB machine can't spare the memory.
+
+### 4. Use Docker Scout / Snyk / Chainguard APIs
+
+Commercial vulnerability scanning APIs.
+
+- **Pro:** Managed infrastructure, high-quality data
+- **Con:** Requires API keys, usage-based pricing, vendor lock-in
+
+Rejected: unnecessary cost and complexity for an open-source tool.
+
+## Consequences
+
+### Positive
+
+- Scans drop from 30-120s (Trivy) to 1-3s (SBOM fetch + OSV API call) for images with SBOMs
+- No subprocess memory pressure -- pure HTTP calls
+- Semaphore no longer needed for the OSV path, enabling true concurrency
+- OSV.dev aggregates multiple vulnerability databases (NVD, GitHub Advisory, Debian, Alpine, etc.)
+
+### Negative
+
+- Two code paths to maintain (OSV for SBOM images, Trivy for non-SBOM images)
+- OSV.dev coverage may differ slightly from Trivy's database (Trivy includes some commercial feeds)
+- SBOM quality depends on image publisher -- incomplete SBOMs produce incomplete results
+- External API dependency (OSV.dev availability)
+
+### Neutral
+
+- Frontend is unaffected -- both paths produce the same `ScanResult` JSON
+- Cache behavior is identical
+- VEX cross-referencing works the same way
+
+## Implementation Notes
+
+- Add `osv/` package with `QueryBatch` and SBOM-to-query mapping
+- Modify `handleScanImage` to check for SBOM referrers before falling through to Trivy
+- Consider showing the scan source in the UI (e.g., "Scanned via SBOM + OSV" vs "Scanned via Trivy")
+- For images with >1000 packages, split into multiple batch requests

--- a/main.go
+++ b/main.go
@@ -548,11 +548,12 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	countRequest("scan")
-	slog.Info("scan", "image", imageRef)
-	slog.Debug("scan", "image", imageRef, "remote_addr", r.RemoteAddr)
 
 	force := r.URL.Query().Get("force") == "1"
 	peek := r.URL.Query().Get("peek") == "1"
+	start := time.Now()
+
+	slog.Info("scan request", "image", imageRef, "force", force, "peek", peek)
 
 	// Peek mode: check cache only, return 404 on miss (never triggers Trivy).
 	// Used by the frontend to instantly show cached results after inspect.
@@ -561,6 +562,7 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			data, cachedAt, err := cacheStore.Get(r.Context(), "scan/"+digest)
 			if err == nil {
+				slog.Info("scan peek hit", "image", imageRef, "duration", time.Since(start).Round(time.Millisecond))
 				w.Header().Set("Content-Type", "application/json")
 				w.Header().Set("X-Cache", "HIT")
 				if !cachedAt.IsZero() {
@@ -570,6 +572,7 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+		slog.Info("scan peek miss", "image", imageRef, "duration", time.Since(start).Round(time.Millisecond))
 		w.WriteHeader(http.StatusNotFound)
 		writeJSON(w, APIResponse{Success: false, Error: "no cached scan results"})
 		return
@@ -586,13 +589,13 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 				return json.Marshal(APIResponse{Success: true, Data: scanResult})
 			})
 			if err == nil {
-				w.Header().Set("Content-Type", "application/json")
+				cacheStatus := "MISS"
 				if result.FromCache {
-					w.Header().Set("X-Cache", "HIT")
-				} else {
-					w.Header().Set("X-Cache", "MISS")
+					cacheStatus = "HIT"
 				}
-				// Inject cachedAt for the frontend to show staleness
+				slog.Info("scan response", "image", imageRef, "cache", cacheStatus, "duration", time.Since(start).Round(time.Millisecond))
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Cache", cacheStatus)
 				if !result.CachedAt.IsZero() {
 					w.Header().Set("X-Cached-At", result.CachedAt.UTC().Format(time.RFC3339))
 				}
@@ -608,7 +611,7 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 	// Force refresh or uncached path -- also store in cache if available
 	scanResult, err := scanner.ScanImage(r.Context(), imageRef)
 	if err != nil {
-		slog.Error("scan failed", "image", imageRef, "error", err)
+		slog.Error("scan failed", "image", imageRef, "duration", time.Since(start).Round(time.Millisecond), "error", err)
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -627,7 +630,7 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	logVerbose("Scan complete for %s: %d vulnerabilities found", imageRef, scanResult.TotalCount)
+	slog.Info("scan response", "image", imageRef, "cache", "NONE", "vulns", scanResult.TotalCount, "duration", time.Since(start).Round(time.Millisecond))
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, APIResponse{Success: true, Data: scanResult})
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os/exec"
 	"sort"
 	"strings"
@@ -22,9 +22,13 @@ func SetVerbose(v bool) {
 // logVerbose prints a message only if verbose mode is enabled
 func logVerbose(format string, args ...any) {
 	if verbose {
-		log.Printf("[VERBOSE] [scanner] "+format, args...)
+		slog.Debug(fmt.Sprintf(format, args...), "component", "scanner")
 	}
 }
+
+// scanSem limits concurrent Trivy processes to 1 to prevent OOM on
+// memory-constrained hosts (e.g., 512 MB Fly.io machines).
+var scanSem = make(chan struct{}, 1)
 
 // TrivyReport is the top-level Trivy JSON output structure.
 type TrivyReport struct {
@@ -109,6 +113,7 @@ type TargetSummary struct {
 }
 
 // ScanImage runs trivy against the given image reference and returns processed results.
+// Only one Trivy process runs at a time; additional callers block until the semaphore is available.
 func ScanImage(ctx context.Context, imageRef string) (*ScanResult, error) {
 	// Check that trivy is installed
 	trivyPath, err := exec.LookPath("trivy")
@@ -117,21 +122,33 @@ func ScanImage(ctx context.Context, imageRef string) (*ScanResult, error) {
 	}
 	logVerbose("Found trivy at: %s", trivyPath)
 
+	// Acquire semaphore — at most 1 concurrent Trivy process
+	select {
+	case scanSem <- struct{}{}:
+		defer func() { <-scanSem }()
+	case <-ctx.Done():
+		return nil, fmt.Errorf("scan cancelled while waiting for semaphore: %w", ctx.Err())
+	}
+
 	// Run trivy with a 5-minute timeout
 	scanCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	logVerbose("Scanning image: %s", imageRef)
-	cmd := exec.CommandContext(scanCtx, trivyPath, "image", "--format", "json", "--quiet", imageRef)
+	slog.Info("scan started", "image", imageRef)
+	start := time.Now()
+	cmd := exec.CommandContext(scanCtx, trivyPath, "image", "--format", "json", "--quiet", "--scanners", "vuln", imageRef)
 	output, err := cmd.Output()
+	duration := time.Since(start)
 	if err != nil {
 		if scanCtx.Err() == context.DeadlineExceeded {
+			slog.Error("scan timed out", "image", imageRef, "duration", duration.Round(time.Millisecond))
 			return nil, fmt.Errorf("trivy scan timed out after 5 minutes")
 		}
-		// Include stderr in the error message if available
 		if exitErr, ok := err.(*exec.ExitError); ok {
+			slog.Error("scan failed", "image", imageRef, "duration", duration.Round(time.Millisecond), "stderr", string(exitErr.Stderr))
 			return nil, fmt.Errorf("trivy scan failed: %s", string(exitErr.Stderr))
 		}
+		slog.Error("scan failed", "image", imageRef, "duration", duration.Round(time.Millisecond), "error", err)
 		return nil, fmt.Errorf("trivy scan failed: %w", err)
 	}
 	logVerbose("Trivy output: %d bytes", len(output))
@@ -142,7 +159,7 @@ func ScanImage(ctx context.Context, imageRef string) (*ScanResult, error) {
 	}
 
 	result := processReport(report)
-	logVerbose("Scan complete: %d total vulnerabilities across %d targets", result.TotalCount, len(result.Targets))
+	slog.Info("scan complete", "image", imageRef, "duration", duration.Round(time.Millisecond), "vulns", result.TotalCount, "targets", len(result.Targets))
 	return result, nil
 }
 

--- a/web/src/components/ScanSection.svelte
+++ b/web/src/components/ScanSection.svelte
@@ -13,6 +13,17 @@
   let scanError = $state('');
   let scanStep = $state('');
   let globalStatusFilter = $state<'all' | 'fixable' | 'nofix' | 'vexed'>('all');
+  let elapsedSeconds = $state(0);
+  let timerInterval = $state<ReturnType<typeof setInterval> | null>(null);
+
+  function startTimer() {
+    elapsedSeconds = 0;
+    timerInterval = setInterval(() => { elapsedSeconds++; }, 1000);
+  }
+
+  function stopTimer() {
+    if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
+  }
 
   // On mount, check if cached scan results exist (non-blocking, never triggers Trivy)
   $effect(() => {
@@ -78,6 +89,7 @@
     scanError = '';
     scanResult = null;
     scanCachedAt = undefined;
+    startTimer();
 
     try {
       scanStep = 'Scanning with Trivy...';
@@ -122,6 +134,7 @@
       scanError = (err as Error).message;
       scanStep = '';
     } finally {
+      stopTimer();
       isScanning = false;
     }
   }
@@ -137,7 +150,7 @@
       </svg>
       <span class="font-semibold text-slate-100">Vulnerability Scan</span>
       {#if isScanning}
-        <span class="text-sm text-slate-400">{scanStep}</span>
+        <span class="text-sm text-slate-400">{scanStep}{#if elapsedSeconds > 0} {elapsedSeconds}s{/if}</span>
       {:else if scanResult && summaryStats}
         <div class="flex items-center gap-1.5 flex-wrap">
           {#if summaryStats.total === 0}


### PR DESCRIPTION
## Summary

- Add `--scanners vuln` flag to Trivy invocation, skipping unnecessary misconfig/secret/license scanners
- Show elapsed time in the scan UI ("Scanning with Trivy... 12s") so users know it's working
- Add a semaphore limiting concurrent Trivy processes to 1, preventing OOM on the 512 MB Fly.io machine
- Switch scanner package from `log.Printf` to `slog` so logs render as structured JSON on Fly.io
- Add duration, cache status, and vulnerability count to all scan-related log lines
- Add ADR-003 proposing SBOM + OSV.dev as a future alternative to Trivy for images with SBOM referrers

## Test plan

- [ ] Verify `go build ./scanner/` and `go test ./scanner/` pass
- [ ] Trigger a scan on the hosted instance and confirm elapsed timer ticks in the UI
- [ ] Check Fly.io logs for structured JSON with duration and cache fields
- [ ] Trigger two concurrent scans for different images and confirm the second queues behind the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)