### PR TITLE
fix(cache): split inspect cache — referrers always fresh

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func getRequestCounts() map[string]uint64 {
 // Cache TTLs per endpoint type. All keys are SHA256 digest-based;
 // the tag-to-digest resolution (ResolveDigest) runs on every request and is never cached.
 const (
-	inspectCacheTTL = 1 * time.Hour       // 1 hour -- referrer list can grow after image push
+	inspectCacheTTL = 30 * 24 * time.Hour // 30 days -- manifest/config/layers are immutable
 	scanCacheTTL    = 24 * time.Hour      // 24 hours -- Trivy DB updates daily
 	sbomCacheTTL    = 30 * 24 * time.Hour // 30 days -- content-addressed, immutable
 	vexCacheTTL     = 30 * 24 * time.Hour // 30 days -- content-addressed, immutable
@@ -538,8 +538,10 @@ type inspectResult struct {
 	Cached    bool // true if cache was involved at all (hit or miss)
 }
 
-// inspectImage fetches image info using the cache if available, falling back to
-// a direct registry call.
+// inspectImage fetches image info using the cache for the base data
+// (manifest, config, layers — immutable for a digest) and always fetches
+// referrers fresh from the registry since they can be attached after the
+// image is pushed.
 func inspectImage(r *http.Request, imageRef string) (*inspectResult, error) {
 	if cacheStore != nil {
 		digest, err := registry.ResolveDigest(imageRef)
@@ -550,6 +552,7 @@ func inspectImage(r *http.Request, imageRef string) (*inspectResult, error) {
 				if err != nil {
 					return nil, err
 				}
+				// Cache the full response including referrers from the initial fetch
 				sr := score.Compute(info.Referrers, info.Manifest, info.Config)
 				return json.Marshal(APIResponse{Success: true, Data: ImageInfoWithScore{ImageInfo: info, Score: sr}})
 			})
@@ -558,7 +561,13 @@ func inspectImage(r *http.Request, imageRef string) (*inspectResult, error) {
 					Data registry.ImageInfo `json:"data"`
 				}
 				if err := json.Unmarshal(result.Data, &apiResp); err == nil {
-					return &inspectResult{Info: &apiResp.Data, FromCache: result.FromCache, Cached: true}, nil
+					info := &apiResp.Data
+					// Always refresh referrers — they can be attached after the image is pushed
+					if result.FromCache {
+						client := registry.NewClient()
+						client.PopulateReferrers(info)
+					}
+					return &inspectResult{Info: info, FromCache: result.FromCache, Cached: true}, nil
 				}
 			}
 		}

--- a/registry/client.go
+++ b/registry/client.go
@@ -277,8 +277,29 @@ func (c *Client) InspectImage(imageRef string) (*ImageInfo, error) {
 		logVerbose("Unknown media type: %s", desc.MediaType)
 	}
 
-	// Fetch referrers - check the index digest and all platform manifest digests in parallel
+	// Fetch referrers and attach them to the info struct
+	c.PopulateReferrers(info)
+
+	// Only show the tag that was requested, not all tags in the repository
+	// (fetching all tags is expensive and usually not what users want)
+	logVerbose("Using requested tag: %s", info.Tag)
+
+	logVerbose("Image inspection complete")
+	return info, nil
+}
+
+// PopulateReferrers fetches all referrers (OCI 1.1 artifacts, cosign tags) for
+// the image described by info and sets info.Referrers. It can be called
+// independently of InspectImage to refresh referrers without re-fetching the
+// manifest, config, and layers.
+func (c *Client) PopulateReferrers(info *ImageInfo) {
 	logVerbose("Fetching referrers (OCI 1.1 artifacts)...")
+
+	ref, err := name.ParseReference(info.Repository + "@" + info.Digest)
+	if err != nil {
+		logVerbose("Failed to parse reference for referrers: %v", err)
+		return
+	}
 
 	var (
 		referrersMu     sync.Mutex
@@ -286,7 +307,6 @@ func (c *Client) InspectImage(imageRef string) (*ImageInfo, error) {
 		existingDigests = make(map[string]bool)
 	)
 
-	// Helper function to safely add referrers
 	addReferrers := func(newReferrers []Referrer) {
 		referrersMu.Lock()
 		defer referrersMu.Unlock()
@@ -298,7 +318,6 @@ func (c *Client) InspectImage(imageRef string) (*ImageInfo, error) {
 		}
 	}
 
-	// Helper function to safely add a single referrer
 	addReferrer := func(r Referrer) {
 		referrersMu.Lock()
 		defer referrersMu.Unlock()
@@ -312,8 +331,8 @@ func (c *Client) InspectImage(imageRef string) (*ImageInfo, error) {
 
 	// Fetch referrers for the main digest (index for multi-platform images) in parallel
 	g.Go(func() error {
-		indexReferrers, _ := c.fetchReferrers(ref, desc.Digest.String())
-		logVerbose("Found %d referrers for index digest %s", len(indexReferrers), truncateDigest(desc.Digest.String()))
+		indexReferrers, _ := c.fetchReferrers(ref, info.Digest)
+		logVerbose("Found %d referrers for index digest %s", len(indexReferrers), truncateDigest(info.Digest))
 		addReferrers(indexReferrers)
 		return nil
 	})
@@ -342,19 +361,6 @@ func (c *Client) InspectImage(imageRef string) (*ImageInfo, error) {
 
 			// Check for Docker BuildKit attestation manifests (used by Kairos and other images)
 			// These have annotation vnd.docker.reference.type: attestation-manifest
-			//
-			// Mapping between com.docker.official-images.bashbrew.arch and platform tags:
-			//   - "amd64"     -> "linux/amd64"
-			//   - "arm32v6"   -> "linux/arm/v6"
-			//   - "arm32v7"   -> "linux/arm/v7"
-			//   - "arm64v8"   -> "linux/arm64/v8"
-			//   - "i386"      -> "linux/386"
-			//   - "ppc64le"   -> "linux/ppc64le"
-			//   - "riscv64"   -> "linux/riscv64"
-			//   - "s390x"     -> "linux/s390x"
-			//
-			// The attestation manifest should have the same com.docker.official-images.bashbrew.arch
-			// annotation as its corresponding platform manifest.
 			if refType, ok := m.Annotations["vnd.docker.reference.type"]; ok && refType == "attestation-manifest" {
 				// Get the platform digest this attestation is linked to
 				platformDigest := m.Annotations["vnd.docker.reference.digest"]
@@ -399,7 +405,7 @@ func (c *Client) InspectImage(imageRef string) (*ImageInfo, error) {
 			}
 
 			// Check referrers API for this manifest (only for actual platform manifests)
-			if m.Digest != desc.Digest.String() && m.Digest != "" && m.Platform != nil {
+			if m.Digest != info.Digest && m.Digest != "" && m.Platform != nil {
 				// Skip attestation manifests - they don't have referrers of their own
 				if _, isAttestation := m.Annotations["vnd.docker.reference.type"]; isAttestation {
 					continue
@@ -435,10 +441,7 @@ func (c *Client) InspectImage(imageRef string) (*ImageInfo, error) {
 	}
 
 	// Discover cosign-tagged artifacts (.sig and .att tags)
-	// Cosign stores signatures and attestations using a tag naming convention:
-	//   sha256-<hex>.sig — cosign signatures
-	//   sha256-<hex>.att — cosign attestations (may contain VEX, provenance, etc.)
-	cosignDigests := []string{desc.Digest.String()}
+	cosignDigests := []string{info.Digest}
 	if info.ImageIndex != nil {
 		for _, m := range info.ImageIndex.Manifests {
 			// Only check real platform manifests, not attestation manifests (unknown/unknown)
@@ -472,13 +475,6 @@ func (c *Client) InspectImage(imageRef string) (*ImageInfo, error) {
 
 	info.Referrers = referrers
 	logVerbose("Total referrers found: %d", len(referrers))
-
-	// Only show the tag that was requested, not all tags in the repository
-	// (fetching all tags is expensive and usually not what users want)
-	logVerbose("Using requested tag: %s", info.Tag)
-
-	logVerbose("Image inspection complete")
-	return info, nil
 }
 
 // MatchingTagsResult holds tags that share the same digest as the queried image.


### PR DESCRIPTION
## Summary

- Extract `PopulateReferrers` from `InspectImage` as a public method on `Client`
- On cache hits, always re-fetch referrers from the registry (~3 lightweight HTTP calls)
- Restore inspect cache TTL to 30 days (manifest/config/layers are truly immutable per digest)
- Replaces the 1-hour TTL from #47 which was too aggressive for the base data

**Root cause:** Referrers (VEX, SBOMs, signatures) are attached AFTER the image is pushed. If the inspect result was cached between the push and referrer attachment, the cached response would be missing those referrers for up to 30 days (previously) or 1 hour (#47 fix).

**This approach:** Cache what's immutable (30 days), fetch what's mutable (always).

## Test plan

- [ ] Inspect an image with VEX — VEX referrers appear on first request
- [ ] Re-inspect same image — base data served from cache, referrers still fresh
- [ ] `go build ./...` and `go test ./registry/ ./scanner/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)