### PR TITLE
infra(fly): use suspend instead of stop for faster cold starts

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,7 +18,7 @@ primary_region = 'fra'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'suspend'
   auto_start_machines = true
   min_machines_running = 0
 


### PR DESCRIPTION
## Summary

- Change `auto_stop_machines` from `stop` to `suspend` in fly.toml
- Suspended machines resume in ~200-500ms vs ~1.5s for stopped machines
- Same cost savings (machine doesn't consume CPU hours when idle), better UX

## Test plan

- [ ] Deploy and verify machine suspends after idle period
- [ ] Confirm faster resume time on next request

🤖 Generated with [Claude Code](https://claude.com/claude-code)