### PR TITLE
fix(ci): install Trivy in release job and remove error suppression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,39 +185,53 @@ jobs:
           subject-digest: ${{ steps.docker-push.outputs.digest }}
           push-to-registry: true
 
+      - name: Install Trivy
+        run: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.69.3/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
+
       - name: Generate and attach OpenVEX documents (per-platform)
         if: inputs.dry-run != true
         run: |
+          set -euo pipefail
+
           IMAGE="ghcr.io/${{ github.repository }}"
           REPO_NAME="${{ github.event.repository.name }}"
           AUTHOR="${{ github.repository_owner }}"
 
-          # Install tools (in case they aren't already available from the action)
           go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           go install github.com/openvex/vexctl@v0.4.1
 
-          # Run govulncheck once — source-level analysis applies to all platforms
-          govulncheck -format json ./... > govulncheck-output.json || true
+          # govulncheck exits non-zero when it finds vulnerabilities — that's expected
+          govulncheck -format json ./... > govulncheck-output.json; GOVULNCHECK_EXIT=$?
+          if [ "$GOVULNCHECK_EXIT" -ne 0 ] && [ "$GOVULNCHECK_EXIT" -ne 3 ]; then
+            echo "::error::govulncheck failed with unexpected exit code $GOVULNCHECK_EXIT"
+            exit 1
+          fi
 
-          # Extract vulnerability IDs
-          CALLED_OSVS=$(jq -r 'select(.finding) | select(.finding.trace[0].function) | .finding.osv' govulncheck-output.json | sort -u || true)
-          ALL_FINDING_OSVS=$(jq -r 'select(.finding) | .finding.osv' govulncheck-output.json | sort -u || true)
-          NOT_CALLED_OSVS=$(comm -23 <(echo "$ALL_FINDING_OSVS") <(echo "$CALLED_OSVS") || true)
+          # Extract vulnerability IDs (empty results are valid — no findings)
+          CALLED_OSVS=$(jq -r 'select(.finding) | select(.finding.trace[0].function) | .finding.osv' govulncheck-output.json | sort -u)
+          ALL_FINDING_OSVS=$(jq -r 'select(.finding) | .finding.osv' govulncheck-output.json | sort -u)
+          NOT_CALLED_OSVS=$(comm -23 <(echo "$ALL_FINDING_OSVS") <(echo "$CALLED_OSVS"))
 
           resolve_aliases() {
             local osv_ids="$1"
             local cves=""
             for osv in $osv_ids; do
-              aliases=$(jq -r "select(.osv) | select(.osv.id == \"$osv\") | .osv.aliases[]" govulncheck-output.json 2>/dev/null | sort -u || true)
+              aliases=$(jq -r "select(.osv) | select(.osv.id == \"$osv\") | .osv.aliases[]" govulncheck-output.json | sort -u)
               cves="$cves $aliases"
             done
-            echo "$cves" | tr ' ' '\n' | grep -E '^CVE-|^GHSA-' | sort -u || true
+            # grep returns exit code 1 when no matches — use || echo to handle empty
+            echo "$cves" | tr ' ' '\n' | { grep -E '^CVE-|^GHSA-' || true; } | sort -u
           }
 
           CALLED_CVES=$(resolve_aliases "$CALLED_OSVS")
           NOT_CALLED_CVES=$(resolve_aliases "$NOT_CALLED_OSVS")
 
-          # Shell function to generate a VEX document for a given product PURL
+          echo "=== govulncheck results ==="
+          echo "Called CVEs: $(echo "$CALLED_CVES" | wc -w | tr -d ' ')"
+          echo "Not-called CVEs: $(echo "$NOT_CALLED_CVES" | wc -w | tr -d ' ')"
+
+          # Shell function to generate a VEX document for a given product PURL.
+          # Each CVE gets an explicit statement — never use NOASSERTION.
           generate_vex() {
             local product="$1"
             rm -f vex.json
@@ -232,7 +246,7 @@ jobs:
               else
                 vexctl add --in-place -p "$product" -v "$CVE" -s under_investigation \
                   --status-note "govulncheck reports this vulnerability as reachable in the call graph" \
-                  vex.json || true
+                  vex.json
               fi
             done
 
@@ -246,15 +260,9 @@ jobs:
                 vexctl add --in-place -p "$product" -v "$CVE" -s not_affected \
                   -j vulnerable_code_not_in_execute_path \
                   --impact-statement "Package is imported but the vulnerable function is not called" \
-                  vex.json || true
+                  vex.json
               fi
             done
-
-            if [ "$first" = true ]; then
-              vexctl create --author="$AUTHOR" --file=vex.json -p "$product" \
-                -v "NOASSERTION" -s not_affected -j vulnerable_code_not_in_execute_path \
-                --impact-statement "govulncheck found no reachable or imported vulnerabilities"
-            fi
           }
 
           # Extract platform manifest digests (skip unknown/unknown attestation manifests)
@@ -267,22 +275,18 @@ jobs:
           # Scan built image with Trivy to find CVEs in bundled binaries (e.g., Trivy itself)
           # that govulncheck can't see (it only analyzes this project's source code).
           FIRST_DIGEST=$(echo "$PLATFORM_DIGESTS" | head -1)
-          TRIVY_CVES=""
-          if command -v trivy &>/dev/null; then
-            TRIVY_CVES=$(trivy image --quiet --format json "${IMAGE}@${FIRST_DIGEST}" 2>/dev/null \
-              | jq -r '.Results[]? | select(.Target != "usr/local/bin/oci-explorer") | .Vulnerabilities[]?.VulnerabilityID' \
-              | sort -u || true)
-          fi
+          echo "=== Trivy scan of bundled binaries (${FIRST_DIGEST}) ==="
+          TRIVY_CVES=$(trivy image --quiet --format json --scanners vuln "${IMAGE}@${FIRST_DIGEST}" \
+            | jq -r '.Results[] | select(.Target != "usr/local/bin/oci-explorer") | .Vulnerabilities[]? | .VulnerabilityID' \
+            | sort -u)
+          echo "Trivy CVEs in bundled binaries: $(echo "$TRIVY_CVES" | wc -w | tr -d ' ')"
 
           # CVEs found by Trivy in bundled binaries but NOT in govulncheck output
-          # are from third-party binaries (e.g., Trivy). These are not_affected for
-          # OCI Explorer because the vulnerable code is in a separate binary that
-          # does not handle external input in the affected code path.
           GOVULNCHECK_CVES=$(echo "$CALLED_CVES $NOT_CALLED_CVES" | tr ' ' '\n' | sort -u)
-          BUNDLED_BINARY_CVES=$(comm -23 <(echo "$TRIVY_CVES") <(echo "$GOVULNCHECK_CVES") 2>/dev/null || true)
+          BUNDLED_BINARY_CVES=$(comm -23 <(echo "$TRIVY_CVES") <(echo "$GOVULNCHECK_CVES"))
 
+          echo "Bundled binary CVEs (not in our code): $(echo "$BUNDLED_BINARY_CVES" | wc -w | tr -d ' ')"
           if [ -n "$BUNDLED_BINARY_CVES" ]; then
-            echo "CVEs in bundled third-party binaries (not in OCI Explorer code):"
             echo "$BUNDLED_BINARY_CVES"
           fi
 
@@ -294,13 +298,25 @@ jobs:
 
             # Append not_affected statements for CVEs in bundled binaries
             for CVE in $BUNDLED_BINARY_CVES; do
-              vexctl add --in-place -p "$PRODUCT" -v "$CVE" -s not_affected \
-                -j vulnerable_code_not_in_execute_path \
-                --impact-statement "Vulnerability is in a bundled third-party binary (e.g., Trivy), not in OCI Explorer code. The affected code path is not externally reachable in this deployment context." \
-                vex.json || true
+              if [ ! -f vex.json ]; then
+                vexctl create --author="$AUTHOR" --file=vex.json -p "$PRODUCT" \
+                  -v "$CVE" -s not_affected -j vulnerable_code_not_in_execute_path \
+                  --impact-statement "Vulnerability is in a bundled third-party binary, not in OCI Explorer code"
+              else
+                vexctl add --in-place -p "$PRODUCT" -v "$CVE" -s not_affected \
+                  -j vulnerable_code_not_in_execute_path \
+                  --impact-statement "Vulnerability is in a bundled third-party binary, not in OCI Explorer code" \
+                  vex.json
+              fi
             done
 
-            echo "Generated vex.json for $DIGEST:"
+            if [ ! -f vex.json ]; then
+              echo "::error::No VEX document generated for $DIGEST — no CVEs found by govulncheck or Trivy"
+              exit 1
+            fi
+
+            STMT_COUNT=$(jq '.statements | length' vex.json)
+            echo "Generated vex.json for $DIGEST ($STMT_COUNT statements):"
             cat vex.json
 
             cosign attest --yes --verbose \
@@ -322,9 +338,6 @@ jobs:
 
       - name: Install verification tools
         if: inputs.dry-run != true
-        run: |
-          # Install Trivy
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.69.3/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
 
       - name: Verify signatures and attestations (smoke test)
         if: inputs.dry-run != true
@@ -351,7 +364,7 @@ jobs:
             --type openvex \
             --certificate-identity-regexp="https://github.com/${{ github.repository }}" \
             --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-            "${IMAGE}@${PLATFORM_DIGEST}" 2>/dev/null \
+            "${IMAGE}@${PLATFORM_DIGEST}" \
             | head -1 | jq -r '.payload' | base64 -d | jq '.predicate' > extracted-vex.json
           echo "Extracted VEX document:"
           jq '.' extracted-vex.json
@@ -360,8 +373,22 @@ jobs:
           jq -e '.["@context"] and .statements' extracted-vex.json > /dev/null
           echo "VEX document has valid OpenVEX structure (context + statements present)"
 
-          echo "=== 5. Trivy: scan with VEX from OCI attestation ==="
-          trivy image --vex oci --format table "${IMAGE}@${PLATFORM_DIGEST}" || true
+          echo "=== 5. Validate VEX has specific CVE statements (not just NOASSERTION) ==="
+          STMT_COUNT=$(jq '.statements | length' extracted-vex.json)
+          NOASSERTION_COUNT=$(jq '[.statements[] | select(.vulnerability.name == "NOASSERTION")] | length' extracted-vex.json)
+          echo "Total statements: $STMT_COUNT, NOASSERTION: $NOASSERTION_COUNT"
+          if [ "$STMT_COUNT" -eq 0 ]; then
+            echo "::error::VEX document has no statements"
+            exit 1
+          fi
+          if [ "$STMT_COUNT" -eq "$NOASSERTION_COUNT" ]; then
+            echo "::error::VEX document only contains NOASSERTION statements — CVE-specific statements are missing"
+            exit 1
+          fi
+          echo "VEX document has $STMT_COUNT specific CVE statements"
+
+          echo "=== 6. Trivy: scan with VEX from OCI attestation ==="
+          trivy image --vex oci --format table --scanners vuln "${IMAGE}@${PLATFORM_DIGEST}"
           echo "Trivy VEX integration check complete"
 
   deploy-fly:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,20 @@ Run `make upgrade` regularly when adding features. It updates Go modules, npm pa
 - Use `_` for intentionally ignored errors only with a comment
 - Return errors from functions, don't just log them
 
+### CI/CD Error Handling
+
+**Never suppress errors in CI workflows.** These patterns are banned:
+
+- `command || true` — masks real failures. If a command can legitimately fail, handle the exit code explicitly (e.g., `command; rc=$?; if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then exit 1; fi`)
+- `command 2>/dev/null` — hides diagnostic output that is critical for debugging CI failures
+- `if command -v tool &>/dev/null` — if a tool is required, install it explicitly and let the step fail if installation fails
+
+**Correct patterns:**
+- `grep pattern || true` is only acceptable inside `{ grep pattern || true; }` (subshell) when the result is piped and empty output is a valid outcome
+- `govulncheck` exits 3 when it finds vulnerabilities — handle this specific exit code, not all errors
+- Every CI step should fail loudly on unexpected errors. Use `set -euo pipefail` at the top of multi-line run blocks
+- Validate outputs: if a step generates a file that downstream steps depend on, verify the file exists and has expected content before proceeding
+
 ### Testing
 
 - Write tests for new functionality


### PR DESCRIPTION
## Summary

Fixes VEX documents only containing `NOASSERTION` instead of specific CVE statements.

**Root cause:** Trivy was not installed in the `release-docker` job. The `if command -v trivy` guard silently skipped the bundled binary scan, and pervasive `|| true` on every command masked the failure. No CVE-specific VEX statements were generated, so the frontend couldn't cross-reference vulnerabilities with the scan results.

**Changes:**
- Install Trivy explicitly before VEX generation
- Remove all `|| true` error suppression from vexctl, trivy, and shell commands
- Handle govulncheck exit code 3 (found vulnerabilities) explicitly
- Add validation: fail the release if VEX only has NOASSERTION statements
- Add `set -euo pipefail` to the VEX generation step
- Log CVE counts at each stage for easier debugging
- Update AGENTS.md with CI error handling policy banning `|| true` and `2>/dev/null`

## Test plan

- [ ] Release workflow generates VEX with specific CVE statements
- [ ] Smoke test validates VEX has non-NOASSERTION entries
- [ ] Scanning the released image on ociexplorer.dev shows "VEXed" count instead of "fixable" for suppressed vulns

🤖 Generated with [Claude Code](https://claude.com/claude-code)