### PR TITLE
fix(ci): remove empty workflow step that broke release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,9 +336,6 @@ jobs:
           path: vex.json
           retention-days: 90
 
-      - name: Install verification tools
-        if: inputs.dry-run != true
-
       - name: Verify signatures and attestations (smoke test)
         if: inputs.dry-run != true
         run: |


### PR DESCRIPTION
## Summary

Hotfix: PR #51 left an empty "Install verification tools" step (no `run` or `uses` property) after moving the Trivy install earlier in the job. GitHub Actions rejects workflows with empty steps, which broke the entire release pipeline.

## Test plan

- [ ] Release workflow starts successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)