### PR TITLE
feat(scan): stream real Trivy output + fix VEX on cached results

### DIFF
--- a/main.go
+++ b/main.go
@@ -652,12 +652,12 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 
 	force := r.URL.Query().Get("force") == "1"
 	peek := r.URL.Query().Get("peek") == "1"
+	stream := r.URL.Query().Get("stream") == "1"
 	start := time.Now()
 
-	slog.Info("scan request", "image", imageRef, "force", force, "peek", peek)
+	slog.Info("scan request", "image", imageRef, "force", force, "peek", peek, "stream", stream)
 
 	// Peek mode: check cache only, return 404 on miss (never triggers Trivy).
-	// Used by the frontend to instantly show cached results after inspect.
 	if peek && cacheStore != nil {
 		digest, err := registry.ResolveDigest(imageRef)
 		if err == nil {
@@ -679,37 +679,63 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check cache (for both streaming and non-streaming requests)
 	if cacheStore != nil && !force {
 		digest, err := registry.ResolveDigest(imageRef)
 		if err == nil {
-			result, err := cacheStore.GetOrCompute(r.Context(), "scan/"+digest, scanCacheTTL, func() ([]byte, error) {
-				scanResult, err := scanner.ScanImage(r.Context(), imageRef)
-				if err != nil {
-					return nil, err
+			// For streaming: check cache, return JSON on hit, fall through to stream on miss
+			if stream {
+				data, cachedAt, err := cacheStore.Get(r.Context(), "scan/"+digest)
+				if err == nil {
+					slog.Info("scan response", "image", imageRef, "cache", "HIT", "duration", time.Since(start).Round(time.Millisecond))
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("X-Cache", "HIT")
+					if !cachedAt.IsZero() {
+						w.Header().Set("X-Cached-At", cachedAt.UTC().Format(time.RFC3339))
+					}
+					writeBytes(w, data)
+					return
 				}
-				return json.Marshal(APIResponse{Success: true, Data: scanResult})
-			})
-			if err == nil {
-				cacheStatus := "MISS"
-				if result.FromCache {
-					cacheStatus = "HIT"
+				// Cache miss — fall through to streaming path
+			} else {
+				result, err := cacheStore.GetOrCompute(r.Context(), "scan/"+digest, scanCacheTTL, func() ([]byte, error) {
+					scanResult, err := scanner.ScanImage(r.Context(), imageRef)
+					if err != nil {
+						return nil, err
+					}
+					return json.Marshal(APIResponse{Success: true, Data: scanResult})
+				})
+				if err == nil {
+					cacheStatus := "MISS"
+					if result.FromCache {
+						cacheStatus = "HIT"
+					}
+					slog.Info("scan response", "image", imageRef, "cache", cacheStatus, "duration", time.Since(start).Round(time.Millisecond))
+					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("X-Cache", cacheStatus)
+					if !result.CachedAt.IsZero() {
+						w.Header().Set("X-Cached-At", result.CachedAt.UTC().Format(time.RFC3339))
+					}
+					writeBytes(w, result.Data)
+					return
 				}
-				slog.Info("scan response", "image", imageRef, "cache", cacheStatus, "duration", time.Since(start).Round(time.Millisecond))
-				w.Header().Set("Content-Type", "application/json")
-				w.Header().Set("X-Cache", cacheStatus)
-				if !result.CachedAt.IsZero() {
-					w.Header().Set("X-Cached-At", result.CachedAt.UTC().Format(time.RFC3339))
-				}
-				writeBytes(w, result.Data)
+				// Return scan errors immediately instead of falling through to a second attempt
+				slog.Error("scan failed", "image", imageRef, "duration", time.Since(start).Round(time.Millisecond), "error", err)
+				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
-			slog.Warn("cache path failed, falling through", "image", imageRef, "error", err)
 		} else {
 			slog.Warn("digest resolution failed, falling through", "image", imageRef, "error", err)
 		}
 	}
 
-	// Force refresh or uncached path -- also store in cache if available
+	// Streaming path
+	if stream {
+		handleScanStream(w, r, imageRef, start)
+		return
+	}
+
+	// Non-streaming uncached/force path
 	scanResult, err := scanner.ScanImage(r.Context(), imageRef)
 	if err != nil {
 		slog.Error("scan failed", "image", imageRef, "duration", time.Since(start).Round(time.Millisecond), "error", err)
@@ -717,21 +743,63 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// On force refresh with cache enabled, store the fresh result
-	if cacheStore != nil && force {
-		if digest, err := registry.ResolveDigest(imageRef); err == nil {
-			data, err := json.Marshal(APIResponse{Success: true, Data: scanResult})
-			if err == nil {
-				go func() {
-					if setErr := cacheStore.Set(context.Background(), "scan/"+digest, data, scanCacheTTL); setErr != nil {
-						slog.Warn("cache set failed after force rescan", "image", imageRef, "error", setErr)
-					}
-				}()
-			}
-		}
-	}
+	storeScanInCache(imageRef, scanResult)
 
 	slog.Info("scan response", "image", imageRef, "cache", "NONE", "vulns", scanResult.TotalCount, "duration", time.Since(start).Round(time.Millisecond))
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, APIResponse{Success: true, Data: scanResult})
+}
+
+// storeScanInCache saves a scan result to S3 cache in the background.
+func storeScanInCache(imageRef string, scanResult *scanner.ScanResult) {
+	if cacheStore == nil {
+		return
+	}
+	if digest, err := registry.ResolveDigest(imageRef); err == nil {
+		data, err := json.Marshal(APIResponse{Success: true, Data: scanResult})
+		if err == nil {
+			go func() {
+				if setErr := cacheStore.Set(context.Background(), "scan/"+digest, data, scanCacheTTL); setErr != nil {
+					slog.Warn("cache set failed", "image", imageRef, "error", setErr)
+				}
+			}()
+		}
+	}
+}
+
+// handleScanStream runs a Trivy scan and streams progress via Server-Sent Events.
+func handleScanStream(w http.ResponseWriter, r *http.Request, imageRef string, start time.Time) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher.Flush()
+
+	sendSSE := func(event, data string) {
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+		flusher.Flush()
+	}
+
+	scanResult, err := scanner.ScanImageStream(r.Context(), imageRef, func(msg string) {
+		msgJSON, _ := json.Marshal(map[string]string{"message": msg})
+		sendSSE("progress", string(msgJSON))
+	})
+	if err != nil {
+		slog.Error("scan failed", "image", imageRef, "duration", time.Since(start).Round(time.Millisecond), "error", err)
+		errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
+		sendSSE("error", string(errJSON))
+		return
+	}
+
+	storeScanInCache(imageRef, scanResult)
+
+	resultJSON, _ := json.Marshal(APIResponse{Success: true, Data: scanResult})
+	sendSSE("result", string(resultJSON))
+
+	slog.Info("scan response (streamed)", "image", imageRef, "vulns", scanResult.TotalCount, "duration", time.Since(start).Round(time.Millisecond))
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -155,6 +157,94 @@ func ScanImage(ctx context.Context, imageRef string) (*ScanResult, error) {
 
 	var report TrivyReport
 	if err := json.Unmarshal(output, &report); err != nil {
+		return nil, fmt.Errorf("failed to parse trivy output: %w", err)
+	}
+
+	result := processReport(report)
+	slog.Info("scan complete", "image", imageRef, "duration", duration.Round(time.Millisecond), "vulns", result.TotalCount, "targets", len(result.Targets))
+	return result, nil
+}
+
+// extractTrivyMessage strips the timestamp/level prefix from a Trivy log line
+// and returns the message part. Returns "" for progress bar noise.
+func extractTrivyMessage(line string) string {
+	// Skip progress bar lines (contain ASCII bar characters and MiB/KiB)
+	if strings.Contains(line, "MiB") || strings.Contains(line, "KiB") || strings.Contains(line, "p/s") {
+		return ""
+	}
+	// Skip empty lines
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return ""
+	}
+	// Trivy log format: "2026-03-29T12:34:52+02:00\tINFO\t[component] message\tkey=val"
+	// Strip timestamp and level prefix, return the rest
+	parts := strings.SplitN(line, "\t", 3)
+	if len(parts) >= 3 {
+		return strings.TrimSpace(parts[2])
+	}
+	// If no tabs (unexpected format), return the whole line
+	return line
+}
+
+// ScanImageStream is like ScanImage but streams Trivy's stderr log lines
+// to the caller via onProgress. Each call receives the actual Trivy log
+// message with the timestamp stripped.
+func ScanImageStream(ctx context.Context, imageRef string, onProgress func(msg string)) (*ScanResult, error) {
+	trivyPath, err := exec.LookPath("trivy")
+	if err != nil {
+		return nil, fmt.Errorf("trivy is not installed or not in PATH: %w", err)
+	}
+
+	select {
+	case scanSem <- struct{}{}:
+		defer func() { <-scanSem }()
+	case <-ctx.Done():
+		return nil, fmt.Errorf("scan cancelled while waiting for semaphore: %w", ctx.Err())
+	}
+
+	scanCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	slog.Info("scan started (streaming)", "image", imageRef)
+	start := time.Now()
+
+	// Run without --quiet so stderr has progress info
+	cmd := exec.CommandContext(scanCtx, trivyPath, "image", "--format", "json", "--scanners", "vuln", imageRef)
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start trivy: %w", err)
+	}
+
+	// Stream stderr line-by-line
+	sc := bufio.NewScanner(stderr)
+	for sc.Scan() {
+		if msg := extractTrivyMessage(sc.Text()); msg != "" {
+			onProgress(msg)
+		}
+	}
+
+	err = cmd.Wait()
+	duration := time.Since(start)
+	if err != nil {
+		if scanCtx.Err() == context.DeadlineExceeded {
+			slog.Error("scan timed out", "image", imageRef, "duration", duration.Round(time.Millisecond))
+			return nil, fmt.Errorf("trivy scan timed out after 5 minutes")
+		}
+		slog.Error("scan failed", "image", imageRef, "duration", duration.Round(time.Millisecond), "error", err)
+		return nil, fmt.Errorf("trivy scan failed: %w", err)
+	}
+
+	var report TrivyReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		return nil, fmt.Errorf("failed to parse trivy output: %w", err)
 	}
 

--- a/web/src/components/ScanResults.svelte
+++ b/web/src/components/ScanResults.svelte
@@ -20,6 +20,24 @@
 
   // Filter state: which severities are enabled (all on by default)
   let enabledSeverities = $state(new Set(severityOrder));
+  let showVexedInChips = $state(false);
+
+  // Counts excluding VEXed entries
+  let unvexedCounts = $derived.by(() => {
+    const counts: Record<string, number> = {};
+    let total = 0;
+    for (const sev of severityOrder) {
+      const vulns = result.bySeverity[sev] || [];
+      const count = vulns.filter((v) => !v.vexStatus).length;
+      counts[sev] = count;
+      total += count;
+    }
+    counts['_total'] = total;
+    return counts;
+  });
+
+  let chipTotal = $derived(showVexedInChips ? result.totalCount : unvexedCounts['_total']);
+  let hasVexedItems = $derived(unvexedCounts['_total'] !== result.totalCount);
 
   // Per-section status filter overrides (when a user clicks chips inside a severity group header)
   let sectionFilters = $state<Record<string, 'all' | 'fixable' | 'nofix' | 'vexed'>>({});
@@ -172,20 +190,25 @@
     {#each availableSeverities as severity}
       {@const colors = severityColors[severity]}
       {@const active = enabledSeverities.has(severity)}
+      {@const count = showVexedInChips ? result.severityCounts[severity] : unvexedCounts[severity]}
+      {#if count > 0 || showVexedInChips}
       <button
         onclick={() => toggleSeverityFilter(severity)}
         class="px-2.5 py-1 rounded-md text-xs font-semibold transition-colors cursor-pointer {active ? colors.badge : colors.badgeOff + ' line-through'}"
       >
-        {severity}: {result.severityCounts[severity]}
+        {severity}: {count}
       </button>
+      {/if}
     {/each}
     <span class="px-2.5 py-1 rounded-md text-xs font-semibold bg-slate-600/30 text-slate-300">
-      {#if filteredTotal === result.totalCount}
-        Total: {result.totalCount}
-      {:else}
-        Showing: {filteredTotal} / {result.totalCount}
-      {/if}
+      Total: {result.totalCount}
     </span>
+    {#if hasVexedItems}
+      <button
+        onclick={() => showVexedInChips = !showVexedInChips}
+        class="px-2.5 py-1 rounded-md text-xs font-semibold cursor-pointer transition-colors {showVexedInChips ? 'bg-purple-500/30 text-purple-300 ring-1 ring-purple-500/50' : 'bg-purple-500/15 text-purple-400 hover:bg-purple-500/25'}"
+      >{result.totalCount - unvexedCounts['_total']} VEXed</button>
+    {/if}
   </div>
 
   <!-- Severity groups -->
@@ -197,22 +220,24 @@
     {@const sectionOpen = isSectionOpen(severity)}
     {@const eff = effectiveFilter(severity)}
     {#if vulns}
-    <div class="border {colors.border} rounded-lg overflow-hidden">
+    {@const allVexed = stats.fixable === 0 && stats.noFix === 0 && stats.vexed > 0}
+    {@const dimVexed = allVexed && !showVexedInChips}
+    <div class="border {dimVexed ? 'border-slate-700/50' : colors.border} rounded-lg overflow-hidden {dimVexed ? 'opacity-60' : ''}">
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
-        class="px-4 py-2.5 {colors.bg} flex items-center justify-between cursor-pointer"
+        class="px-4 py-2.5 {dimVexed ? 'bg-slate-800/30' : colors.bg} flex items-center justify-between cursor-pointer"
         onclick={() => toggleSection(severity)}
       >
         <div class="flex items-center gap-2">
           <svg
-            class="w-4 h-4 {colors.text} transition-transform flex-shrink-0"
+            class="w-4 h-4 {dimVexed ? 'text-slate-500' : colors.text} transition-transform flex-shrink-0"
             style:transform={sectionOpen ? 'rotate(90deg)' : 'rotate(0deg)'}
             fill="none" stroke="currentColor" viewBox="0 0 24 24"
           >
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
-          <span class="font-semibold {colors.text}">{severity}</span>
+          <span class="font-semibold {dimVexed ? 'text-slate-500' : colors.text}">{severity}</span>
           <span class="text-xs text-slate-400">({vulns.length}{#if vulns.length !== allVulns.length}/{allVulns.length}{/if})</span>
         </div>
         <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -243,7 +268,7 @@
           {#each vulns as vuln}
             {@const vexBadge = getVexBadge(vuln)}
             {@const expanded = isVulnOpen(vuln.vulnerabilityID + vuln.pkgName)}
-            <div class="px-4 py-2.5 hover:bg-slate-800/50 transition-colors">
+            <div class="px-4 py-2.5 hover:bg-slate-800/50 transition-colors {vexBadge && !showVexedInChips ? 'opacity-60' : ''}">
               <!-- svelte-ignore a11y_click_events_have_key_events -->
               <!-- svelte-ignore a11y_no_static_element_interactions -->
               <div
@@ -256,7 +281,7 @@
                       href={vuln.primaryURL}
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="font-mono text-sm {colors.text} hover:underline flex-shrink-0"
+                      class="font-mono text-sm {vexBadge && !showVexedInChips ? 'text-slate-500' : colors.text} hover:underline flex-shrink-0"
                       onclick={(e: MouseEvent) => e.stopPropagation()}
                     >
                       {vuln.vulnerabilityID}
@@ -266,7 +291,9 @@
                     {/if}
                     <span class="text-xs text-slate-400 font-mono truncate">{vuln.pkgName}</span>
                   </div>
-                  {#if vuln.title}
+                  {#if vuln.vexImpact}
+                    <p class="text-xs text-purple-400/70 mt-0.5 truncate">{vuln.vexImpact}</p>
+                  {:else if vuln.title}
                     <p class="text-xs text-slate-400 mt-0.5 truncate">{vuln.title}</p>
                   {/if}
                 </div>

--- a/web/src/components/ScanSection.svelte
+++ b/web/src/components/ScanSection.svelte
@@ -25,6 +25,45 @@
     if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
   }
 
+  // Cross-reference scan results with VEX documents attached to the image.
+  // Must be called for both fresh scans and cached results since the cache
+  // stores raw scan data without VEX annotations.
+  async function applyVEX(result: ScanResult) {
+    const vexReferrers = (data.referrers || []).filter((r) => r.type === 'vex');
+    if (vexReferrers.length === 0) return;
+
+    const vexMap = new Map<string, { status: string; justification?: string; impact?: string }>();
+    for (const vexRef of vexReferrers) {
+      try {
+        const doc: VEXDocument = await api.fetchVEX(data.repository, vexRef.digest);
+        for (const stmt of doc.statements) {
+          const entry = { status: stmt.status, justification: stmt.justification, impact: stmt.impact_statement };
+          if (stmt.vulnerability.name) {
+            vexMap.set(stmt.vulnerability.name, entry);
+          }
+          for (const alias of stmt.vulnerability.aliases || []) {
+            vexMap.set(alias, entry);
+          }
+        }
+      } catch (err) {
+        console.warn('VEX fetch failed for', vexRef.digest, err);
+      }
+    }
+
+    if (vexMap.size > 0) {
+      for (const sevGroup of Object.values(result.bySeverity)) {
+        for (const vuln of sevGroup) {
+          const entry = vexMap.get(vuln.vulnerabilityID);
+          if (entry) {
+            vuln.vexStatus = entry.status;
+            vuln.vexJustification = entry.justification;
+            vuln.vexImpact = entry.impact;
+          }
+        }
+      }
+    }
+  }
+
   // Track which image the current peek is for to discard stale responses
   let peekGeneration = 0;
 
@@ -36,9 +75,11 @@
     scanCachedAt = undefined;
     scanError = '';
     isPeeking = true;
-    api.peekScan(imageRef).then((cached) => {
+    api.peekScan(imageRef).then(async (cached) => {
       if (gen !== peekGeneration) return; // stale response from previous image
       if (cached) {
+        await applyVEX(cached.result);
+        if (gen !== peekGeneration) return; // check again after async VEX fetch
         scanResult = cached.result;
         scanCachedAt = cached.cachedAt;
       }
@@ -71,7 +112,7 @@
         else noFix++;
       }
     }
-    return { total: scanResult.totalCount, fixable, vexed, noFix };
+    return { total: scanResult.totalCount, open: fixable + noFix, fixable, vexed, noFix };
   });
 
   // Determine highest severity for results border color
@@ -100,42 +141,14 @@
     startTimer();
 
     try {
-      scanStep = 'Scanning with Trivy...';
-      const scanResponse = await api.scanImage(imageRef, force);
+      scanStep = 'Starting scan...';
+      const scanResponse = await api.scanImageStream(imageRef, force, (msg) => {
+        scanStep = msg;
+      });
       const result = scanResponse.result;
       scanCachedAt = scanResponse.cachedAt;
 
-      // Cross-reference with VEX (if VEX referrers exist)
-      const vexReferrers = (data.referrers || []).filter((r) => r.type === 'vex');
-      if (vexReferrers.length > 0) {
-        scanStep = 'Cross-referencing with VEX...';
-        const vexMap = new Map<string, string>();
-        for (const vexRef of vexReferrers) {
-          try {
-            const doc: VEXDocument = await api.fetchVEX(data.repository, vexRef.digest);
-            for (const stmt of doc.statements) {
-              if (stmt.vulnerability.name) {
-                vexMap.set(stmt.vulnerability.name, stmt.status);
-              }
-              for (const alias of stmt.vulnerability.aliases || []) {
-                vexMap.set(alias, stmt.status);
-              }
-            }
-          } catch {
-            // VEX fetch failure is non-fatal
-          }
-        }
-
-        if (vexMap.size > 0) {
-          for (const sevGroup of Object.values(result.bySeverity)) {
-            for (const vuln of sevGroup) {
-              const status = vexMap.get(vuln.vulnerabilityID);
-              if (status) vuln.vexStatus = status;
-            }
-          }
-        }
-      }
-
+      await applyVEX(result);
       scanResult = result;
       scanStep = '';
     } catch (err) {
@@ -165,6 +178,7 @@
             <span class="px-2 py-0.5 text-xs rounded bg-green-500/15 text-green-400 font-medium">No vulnerabilities</span>
           {:else}
             <span class="px-2 py-0.5 text-xs rounded bg-slate-500/15 text-slate-300 font-medium">{summaryStats.total} vulnerabilities</span>
+            <span class="px-2 py-0.5 text-xs rounded font-medium {summaryStats.open > 0 ? 'bg-orange-500/15 text-orange-400' : 'bg-green-500/15 text-green-400'}">{summaryStats.open} open</span>
             {#if summaryStats.fixable > 0}
               <button
                 onclick={(e: MouseEvent) => { e.stopPropagation(); globalStatusFilter = globalStatusFilter === 'fixable' ? 'all' : 'fixable'; }}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -55,6 +55,72 @@ export async function scanImage(imageRef: string, force = false): Promise<ScanRe
   };
 }
 
+/**
+ * Stream a Trivy scan via SSE. Calls onProgress with actual Trivy log
+ * messages. Falls back to regular JSON on cache hit.
+ */
+export async function scanImageStream(
+  imageRef: string,
+  force: boolean,
+  onProgress: (msg: string) => void,
+): Promise<ScanResponse> {
+  const url = `/api/scan?image=${encodeURIComponent(imageRef)}&stream=1${force ? '&force=1' : ''}`;
+  const response = await fetch(url);
+  const contentType = response.headers.get('Content-Type') || '';
+
+  // Cache hit — server returns JSON directly
+  if (contentType.includes('application/json')) {
+    const json: APIResponse<ScanResult> = await response.json();
+    if (!json.success) throw new Error(json.error || 'Scan failed');
+    return {
+      result: json.data as ScanResult,
+      cachedAt: response.headers.get('X-Cached-At') || undefined,
+    };
+  }
+
+  // SSE stream
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let finalResult: ScanResponse | null = null;
+  let streamError: string | null = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const parts = buffer.split('\n\n');
+    buffer = parts.pop()!;
+
+    for (const part of parts) {
+      let event = '';
+      let data = '';
+      for (const line of part.split('\n')) {
+        if (line.startsWith('event: ')) event = line.slice(7);
+        else if (line.startsWith('data: ')) data = line.slice(6);
+      }
+      if (!event || !data) continue;
+
+      if (event === 'progress') {
+        const parsed = JSON.parse(data);
+        onProgress(parsed.message);
+      } else if (event === 'result') {
+        const parsed: APIResponse<ScanResult> = JSON.parse(data);
+        if (!parsed.success) throw new Error(parsed.error || 'Scan failed');
+        finalResult = { result: parsed.data as ScanResult };
+      } else if (event === 'error') {
+        const parsed = JSON.parse(data);
+        streamError = parsed.error;
+      }
+    }
+  }
+
+  if (streamError) throw new Error(streamError);
+  if (!finalResult) throw new Error('Scan stream ended without result');
+  return finalResult;
+}
+
 /** Check if cached scan results exist without triggering a Trivy scan. Returns null on miss or timeout. */
 export async function peekScan(imageRef: string): Promise<ScanResponse | null> {
   const controller = new AbortController();

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -150,6 +150,8 @@ export interface VulnSummary {
   target: string;
   targets?: string[];
   vexStatus?: string;
+  vexJustification?: string;
+  vexImpact?: string;
 }
 
 export interface TargetSummary {


### PR DESCRIPTION
## Summary

Supersedes #50. Fixes two bugs and adds streaming.

### Streaming (new)
- Real Trivy stderr log lines streamed to the frontend via SSE (e.g., `[vulndb] Downloading vulnerability DB...`, `Detected OS family="alpine"`)
- Only progress bar noise filtered; all meaningful log lines pass through
- Cache hits bypass streaming and return JSON directly

### VEX cross-referencing (bug fix)
- **Root cause**: VEX was only applied during `doScan()`, never on cached results from `peekScan()`. Since S3 cache stores raw scan data without VEX annotations, cached results always showed "5 fixable" instead of "5 VEXed"
- **Fix**: extracted `applyVEX()` function, called from both `doScan()` and `peekScan()`

### Timeout handling (bug fix)
- Cache path scan errors (e.g., 5-minute timeout) now return immediately instead of falling through to a second scan attempt

## Test plan
- [ ] Scan uncached image — see actual Trivy log lines streaming in real-time
- [ ] Inspect `ghcr.io/hkolvenbach/oci-explorer:latest` — cached scan shows "VEXed" count
- [ ] Force rescan — streaming works, VEX applied after scan completes
- [ ] Scan times out — error shown after 5min, not 10min

🤖 Generated with [Claude Code](https://claude.com/claude-code)