### PR TITLE
feat: cache Trivy DB in S3 for faster cold starts

### DIFF
--- a/HOSTING_ALTERNATIVES.md
+++ b/HOSTING_ALTERNATIVES.md
@@ -1,0 +1,46 @@
+# Hosting Alternatives Research (March 2026)
+
+Current setup: Fly.io shared-cpu-1x, 512MB, Frankfurt — ~$3.60/mo.
+
+## Problem
+
+Shared CPU is fine for inspect/SBOM/VEX (metadata-only, <200KB per request). Trivy vulnerability scans are CPU-intensive (layer decompression + filesystem walk) and time out on shared CPU for images >100MB (nginx times out at 5 min, twice).
+
+## Managed PaaS Comparison
+
+| Platform | Built-in metrics? | Dashboard | Dedicated CPU | Price (dedicated) | Deploy model |
+|---|---|---|---|---|---|
+| **Fly.io** | Yes | Full Grafana + Prometheus endpoint | Yes | $32/mo (1 vCPU, 2GB) | fly.toml, `fly deploy` |
+| **Northflank** | Yes | Real-time metrics + logs, all plans | Yes | $24/mo (1 vCPU, 2GB) | Dockerfile from git |
+| **Railway** | Basic | Logs + usage metrics | No | $5-20 usage-based (shared) | Git push |
+| **Render** | Basic | Logs + deploy history | No (all tiers shared) | $25/mo (1 shared, 2GB) | render.yaml from git |
+| **Koyeb** | Basic | Logs + basic metrics | Partial (0.25 dedicated/GB) | $11/mo (1 vCPU, 1GB) | Git push or Docker |
+
+### Notes
+
+- **Fly.io** has the best integrated observability (Grafana dashboards, Prometheus scraping, live log tailing). No other managed PaaS offers a full Grafana instance.
+- **Northflank** is the closest alternative — built-in metrics on all plans, dedicated CPU at $24/mo ($8 cheaper than Fly.io for equivalent specs).
+- **Railway** has the simplest DX but all CPU is shared/burstable — unsuitable for sustained Trivy scans.
+- **Render** — all tiers are shared CPU, even the $225/mo Pro Max.
+- **Namespace.so** — CI/CD and ephemeral compute only (instances auto-shut after 15 min). Not suitable for long-running services.
+
+## Self-Hosted Option: Hetzner + Coolify
+
+| Hetzner tier | Spec | Price/mo |
+|---|---|---|
+| CX23 (shared) | 2 vCPU, 4GB RAM, 40GB | €3.99 |
+| CPX22 (shared, AMD) | 2 vCPU, 4GB RAM, 80GB | €7.99 |
+| **CCX13 (dedicated)** | **2 dedicated vCPU, 8GB RAM, 80GB** | **€15.99 (~$17)** |
+
+Coolify (free, self-hosted PaaS) provides git-push deploys, auto-SSL, Docker-native deployment, and a basic log/metrics UI. Install with one curl command.
+
+**Trade-off**: Best CPU per dollar (2 dedicated vCPU + 8GB for $17 vs $32 on Fly.io), but you manage OS updates, backups, and monitoring yourself. No integrated Grafana — you'd wire up Prometheus + Grafana manually.
+
+## Decision (March 2026)
+
+Stay on Fly.io shared-cpu-1x for now. Mitigate scan performance via:
+1. Trivy DB S3 caching (eliminates cold-start DB download penalty)
+2. Response caching (repeat scans served from S3)
+3. Consider SBOM-first scanning (avoids full image download for images with SBOM referrers)
+
+Revisit if scan timeouts become a frequent user-facing problem — upgrade to Fly.io performance-1x ($32/mo) or migrate to Hetzner CCX13 + Coolify ($17/mo).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,9 @@ services:
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
       AWS_REGION: us-east-1
+      AWS_EC2_METADATA_DISABLED: "true"   # skip IMDS probes inside Docker
+    volumes:
+      - trivy-cache:/tmp                   # Trivy DBs are ~700MB+ uncompressed; volume avoids tmpfs size limits
     depends_on:
       minio-setup:
         condition: service_completed_successfully
@@ -76,3 +79,4 @@ services:
 
 volumes:
   minio-data:
+  trivy-cache:

--- a/docs/superpowers/specs/2026-03-30-trivy-db-s3-caching-design.md
+++ b/docs/superpowers/specs/2026-03-30-trivy-db-s3-caching-design.md
@@ -1,0 +1,181 @@
+# Trivy DB S3 Caching
+
+**Date:** 2026-03-30
+**Status:** Approved
+
+## Problem
+
+OCI Explorer runs on Fly.io with `min_machines_running = 0`. Every cold start forces Trivy to download its vulnerability DB from upstream (~30-60s), delaying the first scan. The Java DB adds further delay on first Java image scan.
+
+## Solution
+
+Cache the Trivy vulnerability DB and Java DB in S3. On startup, restore from S3 (~2-5s). A background goroutine refreshes from upstream hourly and uploads the new DBs to S3. Scans never trigger their own DB downloads.
+
+## S3 Layout
+
+Two fixed keys in the existing `CACHE_S3_BUCKET`, overwritten on each refresh:
+
+```
+trivy-db/vuln-db.tar.gz    (~40MB, contains db/trivy.db + db/metadata.json)
+trivy-db/java-db.tar.gz    (~10MB, contains java-db/trivy-java.db + java-db/metadata.json)
+```
+
+S3 PutObject is atomic for single-part uploads (<5GB). Combined with S3's strong read-after-write consistency, a GET during a PUT returns the previous complete version. No versioning or multi-key rotation needed.
+
+## New Package: `trivydb`
+
+### Manager
+
+```go
+type Manager struct {
+    s3client  s3API       // S3 GetObject/PutObject (same interface as cache pkg)
+    bucket    string
+    cacheDir  string      // Trivy's --cache-dir
+    trivyPath string      // resolved path to trivy binary
+    cancel    context.CancelFunc
+    wg        sync.WaitGroup
+}
+
+func New(ctx context.Context, bucket, cacheDir string) (*Manager, error)
+func (m *Manager) Start(ctx context.Context) error
+func (m *Manager) Stop()
+func (m *Manager) CacheDir() string
+func (m *Manager) Ready() bool
+func (m *Manager) DBAge() time.Duration
+```
+
+### Startup Flow (`Start`)
+
+1. Resolve Trivy binary path via `exec.LookPath`.
+2. Try restore vuln DB from S3 key `trivy-db/vuln-db.tar.gz` -> extract to `<cacheDir>/db/`.
+3. Try restore Java DB from S3 key `trivy-db/java-db.tar.gz` -> extract to `<cacheDir>/java-db/`.
+4. If either S3 key is missing (first-ever deploy):
+   - Run `trivy image --download-db-only --cache-dir <cacheDir>` for vuln DB.
+   - Run `trivy image --download-java-db-only --cache-dir <cacheDir>` for Java DB.
+   - Upload the newly downloaded DBs to S3.
+5. Mark manager as ready.
+6. Launch background goroutine with hourly ticker.
+
+### Hourly Refresh (non-blocking, Approach A)
+
+1. Create a temp directory.
+2. Run `trivy image --download-db-only --cache-dir <tempDir>`.
+3. Run `trivy image --download-java-db-only --cache-dir <tempDir>`.
+4. Tar+gzip `<tempDir>/db/` and `<tempDir>/java-db/`.
+5. Upload both tarballs to S3.
+6. Swap: `os.Rename` the temp subdirectories over the live ones.
+7. Remove temp directory.
+8. On failure: log warning, keep existing DB, retry next tick.
+
+### Tar/Extract
+
+Implemented in Go using `archive/tar` + `compress/gzip` (distroless has no shell).
+
+- `tarDir(srcDir string) ([]byte, error)` — walks a directory, produces tar.gz bytes.
+- `extractTar(data []byte, destDir string) error` — extracts tar.gz into destination.
+
+Both preserve file permissions but strip absolute paths for safety.
+
+## Scanner Changes
+
+In `scanner.go`, the `ScanImage` function accepts an optional cache dir:
+
+```go
+func ScanImage(ctx context.Context, imageRef string, opts ...ScanOption) (*ScanResult, error)
+```
+
+`ScanOption` is a functional option:
+
+```go
+type ScanOption func(*scanConfig)
+
+type scanConfig struct {
+    cacheDir       string
+    skipDBUpdate   bool
+    skipJavaUpdate bool
+}
+
+func WithCacheDir(dir string) ScanOption
+func WithSkipDBUpdate() ScanOption
+func WithSkipJavaDBUpdate() ScanOption
+```
+
+When a `trivydb.Manager` is active, `main.go` passes all three options. Without the manager, current behavior is preserved (Trivy manages its own DB downloads).
+
+## Integration in `main.go`
+
+After cache store initialization:
+
+```go
+var trivyDBManager *trivydb.Manager
+
+if cacheStore != nil {
+    cacheDir := filepath.Join(os.TempDir(), "trivy-cache")
+    mgr, err := trivydb.New(ctx, bucket, cacheDir)
+    if err != nil {
+        slog.Warn("trivy db cache disabled", "error", err)
+    } else {
+        if err := mgr.Start(ctx); err != nil {
+            slog.Warn("trivy db restore failed, will use upstream", "error", err)
+        }
+        trivyDBManager = mgr
+        defer mgr.Stop()
+    }
+}
+```
+
+Scan handler passes options when manager is active:
+
+```go
+var opts []scanner.ScanOption
+if trivyDBManager != nil && trivyDBManager.Ready() {
+    opts = append(opts,
+        scanner.WithCacheDir(trivyDBManager.CacheDir()),
+        scanner.WithSkipDBUpdate(),
+        scanner.WithSkipJavaDBUpdate(),
+    )
+}
+scanner.ScanImage(ctx, imageRef, opts...)
+```
+
+## Health Endpoint
+
+When the manager is active, the `/api/health` response includes:
+
+```json
+{
+  "trivyDBCached": true,
+  "trivyDBAge": "42m15s"
+}
+```
+
+## Local Testing with MinIO
+
+The existing docker-compose MinIO setup works unchanged. The `trivy-db/` prefix coexists with `scan/`, `inspect/`, etc. in the same bucket.
+
+Manual verification:
+```bash
+# After first scan, check MinIO for DB files:
+mc ls local/oci-cache/trivy-db/
+# Should show vuln-db.tar.gz and java-db.tar.gz
+```
+
+## Graceful Degradation
+
+| Scenario | Behavior |
+|----------|----------|
+| No `CACHE_S3_BUCKET` | Feature disabled, current behavior preserved |
+| S3 restore fails on startup | Trivy downloads from upstream (logs warning) |
+| S3 upload fails after refresh | Log warning, local DB still works, retry next hour |
+| Hourly refresh fails (network) | Log warning, keep existing DB, retry next hour |
+| Trivy binary missing | Manager init fails, feature disabled |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `trivydb/trivydb.go` | New — Manager, startup, refresh, tar/extract |
+| `trivydb/trivydb_test.go` | New — unit tests with mock S3 |
+| `scanner/scanner.go` | Add ScanOption, WithCacheDir, WithSkipDBUpdate, WithSkipJavaDBUpdate |
+| `main.go` | Init Manager, pass scan options, health endpoint additions |
+| `go.mod` / `go.sum` | No new dependencies (uses stdlib + existing AWS SDK) |

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/hkolvenbach/oci-explorer/registry"
 	"github.com/hkolvenbach/oci-explorer/scanner"
 	"github.com/hkolvenbach/oci-explorer/score"
+	"github.com/hkolvenbach/oci-explorer/trivydb"
 )
 
 //go:embed web/dist/*
@@ -42,6 +44,9 @@ var jsonLogs bool
 
 // cacheStore is the global response cache (nil when caching is disabled).
 var cacheStore *cache.Store
+
+// trivyDBManager is the global Trivy DB cache manager (nil when disabled).
+var trivyDBManager *trivydb.Manager
 
 // Cache TTLs per endpoint type. All keys are SHA256 digest-based;
 // the tag-to-digest resolution (ResolveDigest) runs on every request and is never cached.
@@ -160,6 +165,21 @@ func main() {
 		slog.Info("response cache enabled", "bucket", bucket)
 	}
 
+	// Initialize Trivy DB S3 cache if response cache is enabled.
+	if cacheStore != nil {
+		cacheDir := filepath.Join(os.TempDir(), "trivy-cache")
+		mgr, err := trivydb.New(context.Background(), os.Getenv("CACHE_S3_BUCKET"), cacheDir)
+		if err != nil {
+			slog.Warn("trivy DB cache disabled", "error", err)
+		} else {
+			if err := mgr.Start(context.Background()); err != nil {
+				slog.Warn("trivy DB restore failed, scans will use upstream", "error", err)
+			}
+			trivyDBManager = mgr
+			defer mgr.Stop()
+		}
+	}
+
 	// Create docs handler (embed.FS satisfies fs.FS)
 	docsHandler := docshandler.New(docsFS, verbose)
 
@@ -258,6 +278,9 @@ func main() {
 	if cacheStore != nil {
 		fmt.Printf("│  Cache:    %-37s│\n", os.Getenv("CACHE_S3_BUCKET"))
 	}
+	if trivyDBManager != nil {
+		fmt.Println("│  Trivy DB: S3-cached (hourly refresh)            │")
+	}
 	if metricsPort != "" {
 		fmt.Printf("│  Metrics:  http://localhost:%-20s│\n", metricsPort+"/metrics")
 	}
@@ -300,6 +323,13 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	if cacheStore != nil {
 		data["cache"] = cache.Stats()
+	}
+
+	if trivyDBManager != nil {
+		data["trivyDBCached"] = trivyDBManager.Ready()
+		if age := trivyDBManager.DBAge(); age > 0 {
+			data["trivyDBAge"] = age.Round(time.Second).String()
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -607,6 +637,19 @@ func handleBadgeJSON(w http.ResponseWriter, r *http.Request) {
 	writeBytes(w, badge.RenderJSON(*result))
 }
 
+// trivyScanOpts returns scanner options that use the managed Trivy DB cache
+// when available, or no options when the manager is inactive.
+func trivyScanOpts() []scanner.ScanOption {
+	if trivyDBManager == nil || !trivyDBManager.Ready() {
+		return nil
+	}
+	return []scanner.ScanOption{
+		scanner.WithCacheDir(trivyDBManager.CacheDir()),
+		scanner.WithSkipDBUpdate(),
+		scanner.WithSkipJavaDBUpdate(),
+	}
+}
+
 func handleScanImage(w http.ResponseWriter, r *http.Request) {
 	imageRef := r.URL.Query().Get("image")
 	if imageRef == "" {
@@ -664,7 +707,7 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 				// Cache miss — fall through to streaming path
 			} else {
 				result, err := cacheStore.GetOrCompute(r.Context(), "scan/"+digest, scanCacheTTL, func() ([]byte, error) {
-					scanResult, err := scanner.ScanImage(r.Context(), imageRef)
+					scanResult, err := scanner.ScanImage(r.Context(), imageRef, trivyScanOpts()...)
 					if err != nil {
 						return nil, err
 					}
@@ -701,7 +744,7 @@ func handleScanImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Non-streaming uncached/force path
-	scanResult, err := scanner.ScanImage(r.Context(), imageRef)
+	scanResult, err := scanner.ScanImage(r.Context(), imageRef, trivyScanOpts()...)
 	if err != nil {
 		slog.Error("scan failed", "image", imageRef, "duration", time.Since(start).Round(time.Millisecond), "error", err)
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -753,7 +796,7 @@ func handleScanStream(w http.ResponseWriter, r *http.Request, imageRef string, s
 	scanResult, err := scanner.ScanImageStream(r.Context(), imageRef, func(msg string) {
 		msgJSON, _ := json.Marshal(map[string]string{"message": msg})
 		sendSSE("progress", string(msgJSON))
-	})
+	}, trivyScanOpts()...)
 	if err != nil {
 		slog.Error("scan failed", "image", imageRef, "duration", time.Since(start).Round(time.Millisecond), "error", err)
 		errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -123,9 +123,55 @@ type TargetSummary struct {
 	Count  int    `json:"count"`
 }
 
+// scanConfig holds optional configuration for a scan.
+type scanConfig struct {
+	cacheDir       string
+	skipDBUpdate   bool
+	skipJavaUpdate bool
+}
+
+// ScanOption configures a scan.
+type ScanOption func(*scanConfig)
+
+// WithCacheDir sets the Trivy --cache-dir flag.
+func WithCacheDir(dir string) ScanOption {
+	return func(c *scanConfig) { c.cacheDir = dir }
+}
+
+// WithSkipDBUpdate adds --skip-db-update to prevent per-scan DB downloads.
+func WithSkipDBUpdate() ScanOption {
+	return func(c *scanConfig) { c.skipDBUpdate = true }
+}
+
+// WithSkipJavaDBUpdate adds --skip-java-db-update to prevent per-scan Java DB downloads.
+func WithSkipJavaDBUpdate() ScanOption {
+	return func(c *scanConfig) { c.skipJavaUpdate = true }
+}
+
+// trivyArgs builds the Trivy CLI arguments from a scanConfig plus any extra flags.
+func trivyArgs(cfg scanConfig, extra ...string) []string {
+	args := []string{"image"}
+	args = append(args, extra...)
+	args = append(args, "--scanners", "vuln")
+	if cfg.cacheDir != "" {
+		args = append(args, "--cache-dir", cfg.cacheDir)
+	}
+	if cfg.skipDBUpdate {
+		args = append(args, "--skip-db-update")
+	}
+	if cfg.skipJavaUpdate {
+		args = append(args, "--skip-java-db-update")
+	}
+	return args
+}
+
 // ScanImage runs trivy against the given image reference and returns processed results.
 // Only one Trivy process runs at a time; additional callers block until the semaphore is available.
-func ScanImage(ctx context.Context, imageRef string) (*ScanResult, error) {
+func ScanImage(ctx context.Context, imageRef string, opts ...ScanOption) (*ScanResult, error) {
+	var cfg scanConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
 	// Check that trivy is installed
 	trivyPath, err := exec.LookPath("trivy")
 	if err != nil {
@@ -145,9 +191,12 @@ func ScanImage(ctx context.Context, imageRef string) (*ScanResult, error) {
 	scanCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
+	args := trivyArgs(cfg, "--format", "json", "--quiet")
+	args = append(args, imageRef)
+
 	slog.Info("scan started", "image", imageRef)
 	start := time.Now()
-	cmd := exec.CommandContext(scanCtx, trivyPath, "image", "--format", "json", "--quiet", "--scanners", "vuln", imageRef)
+	cmd := exec.CommandContext(scanCtx, trivyPath, args...)
 	output, err := cmd.Output()
 	duration := time.Since(start)
 	if err != nil {
@@ -200,7 +249,11 @@ func extractTrivyMessage(line string) string {
 // ScanImageStream is like ScanImage but streams Trivy's stderr log lines
 // to the caller via onProgress. Each call receives the actual Trivy log
 // message with the timestamp stripped.
-func ScanImageStream(ctx context.Context, imageRef string, onProgress func(msg string)) (*ScanResult, error) {
+func ScanImageStream(ctx context.Context, imageRef string, onProgress func(msg string), opts ...ScanOption) (*ScanResult, error) {
+	var cfg scanConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
 	trivyPath, err := exec.LookPath("trivy")
 	if err != nil {
 		return nil, fmt.Errorf("trivy is not installed or not in PATH: %w", err)
@@ -220,7 +273,9 @@ func ScanImageStream(ctx context.Context, imageRef string, onProgress func(msg s
 	start := time.Now()
 
 	// Run without --quiet so stderr has progress info
-	cmd := exec.CommandContext(scanCtx, trivyPath, "image", "--format", "json", "--scanners", "vuln", imageRef)
+	args := trivyArgs(cfg, "--format", "json")
+	args = append(args, imageRef)
+	cmd := exec.CommandContext(scanCtx, trivyPath, args...)
 
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout

--- a/trivydb/trivydb.go
+++ b/trivydb/trivydb.go
@@ -1,0 +1,461 @@
+// Package trivydb caches the Trivy vulnerability and Java databases in S3
+// to eliminate the 30-60s cold-start penalty when Trivy downloads from upstream.
+//
+// On startup the Manager restores the databases from S3. A background goroutine
+// refreshes from Trivy's upstream every hour and uploads the new databases to S3
+// so subsequent cold starts are fast.
+package trivydb
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+const (
+	vulnDBKey = "trivy-db/vuln-db.tar.gz"
+	javaDBKey = "trivy-db/java-db.tar.gz"
+
+	refreshInterval = 1 * time.Hour
+	trivyTimeout    = 5 * time.Minute
+)
+
+// s3API is the subset of the S3 client used by Manager, enabling test mocks.
+type s3API interface {
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+// Manager handles the Trivy DB lifecycle: restore from S3, periodic refresh,
+// and upload back to S3.
+type Manager struct {
+	client    s3API
+	bucket    string
+	cacheDir  string
+	trivyPath string
+
+	ready      atomic.Bool
+	lastUpdate atomic.Int64 // unix timestamp of last successful refresh
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// New creates a Manager backed by the given S3 bucket.
+// cacheDir is the directory Trivy will use as its --cache-dir.
+func New(ctx context.Context, bucket, cacheDir string) (*Manager, error) {
+	trivyPath, err := exec.LookPath("trivy")
+	if err != nil {
+		return nil, fmt.Errorf("trivydb: trivy not found: %w", err)
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("trivydb: load AWS config: %w", err)
+	}
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("trivydb: create cache dir: %w", err)
+	}
+
+	return &Manager{
+		client:    client,
+		bucket:    bucket,
+		cacheDir:  cacheDir,
+		trivyPath: trivyPath,
+	}, nil
+}
+
+// newWithClient creates a Manager with an injected S3 client (for testing).
+func newWithClient(client s3API, bucket, cacheDir, trivyPath string) *Manager {
+	return &Manager{
+		client:    client,
+		bucket:    bucket,
+		cacheDir:  cacheDir,
+		trivyPath: trivyPath,
+	}
+}
+
+// Start restores databases from S3 (falling back to upstream) and launches the
+// hourly refresh goroutine. It blocks until the initial restore is complete.
+func (m *Manager) Start(ctx context.Context) error {
+	refreshCtx, cancel := context.WithCancel(ctx)
+	m.cancel = cancel
+
+	if err := m.initialRestore(ctx); err != nil {
+		cancel()
+		return err
+	}
+
+	m.ready.Store(true)
+	m.lastUpdate.Store(time.Now().Unix())
+
+	m.wg.Add(1)
+	go m.refreshLoop(refreshCtx)
+
+	return nil
+}
+
+// Stop cancels the background refresh and waits for it to finish.
+func (m *Manager) Stop() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.wg.Wait()
+}
+
+// CacheDir returns the Trivy cache directory managed by this Manager.
+func (m *Manager) CacheDir() string {
+	return m.cacheDir
+}
+
+// Ready returns true once the initial DB restore is complete.
+func (m *Manager) Ready() bool {
+	return m.ready.Load()
+}
+
+// DBAge returns the time since the last successful DB refresh.
+func (m *Manager) DBAge() time.Duration {
+	ts := m.lastUpdate.Load()
+	if ts == 0 {
+		return 0
+	}
+	return time.Since(time.Unix(ts, 0))
+}
+
+// initialRestore tries to restore both DBs from S3. If a key is missing,
+// it downloads from Trivy's upstream and uploads to S3 for next time.
+func (m *Manager) initialRestore(ctx context.Context) error {
+	type dbSpec struct {
+		s3Key   string
+		subDir  string
+		dlFlag  string
+		logName string
+	}
+	dbs := []dbSpec{
+		{vulnDBKey, "db", "--download-db-only", "vuln-db"},
+		{javaDBKey, "java-db", "--download-java-db-only", "java-db"},
+	}
+
+	for _, db := range dbs {
+		destDir := filepath.Join(m.cacheDir, db.subDir)
+		if err := os.MkdirAll(destDir, 0o755); err != nil {
+			return fmt.Errorf("trivydb: create %s dir: %w", db.subDir, err)
+		}
+
+		start := time.Now()
+		data, err := m.downloadFromS3(ctx, db.s3Key)
+		if err == nil {
+			if err := extractTar(data, m.cacheDir); err != nil {
+				slog.Warn("trivydb: S3 restore extract failed, falling back to upstream",
+					"db", db.logName, "error", err)
+			} else {
+				slog.Info("trivydb: restored from S3",
+					"db", db.logName, "duration", time.Since(start).Round(time.Millisecond))
+				continue
+			}
+		} else {
+			slog.Info("trivydb: S3 miss, downloading from upstream", "db", db.logName)
+		}
+
+		// Fall back to upstream
+		start = time.Now()
+		if err := m.trivyDownload(ctx, db.dlFlag); err != nil {
+			slog.Warn("trivydb: upstream download failed",
+				"db", db.logName, "error", err)
+			continue // non-fatal: Trivy will download on first scan
+		}
+		slog.Info("trivydb: downloaded from upstream",
+			"db", db.logName, "duration", time.Since(start).Round(time.Millisecond))
+
+		// Upload to S3 for next cold start
+		go m.uploadDB(context.Background(), db.s3Key, db.subDir, db.logName)
+	}
+
+	return nil
+}
+
+// refreshLoop runs on an hourly ticker, downloading fresh DBs from upstream
+// and uploading them to S3.
+func (m *Manager) refreshLoop(ctx context.Context) {
+	defer m.wg.Done()
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.refresh(ctx)
+		}
+	}
+}
+
+// refresh downloads fresh DBs to a temp directory, uploads to S3, then swaps
+// them into the live cache directory.
+func (m *Manager) refresh(ctx context.Context) {
+	slog.Info("trivydb: hourly refresh starting")
+	start := time.Now()
+
+	tmpDir, err := os.MkdirTemp("", "trivy-refresh-*")
+	if err != nil {
+		slog.Error("trivydb: refresh failed to create temp dir", "error", err)
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+
+	type dbSpec struct {
+		s3Key   string
+		subDir  string
+		dlFlag  string
+		logName string
+	}
+	dbs := []dbSpec{
+		{vulnDBKey, "db", "--download-db-only", "vuln-db"},
+		{javaDBKey, "java-db", "--download-java-db-only", "java-db"},
+	}
+
+	// Download fresh DBs to temp dir
+	for _, db := range dbs {
+		dlCtx, cancel := context.WithTimeout(ctx, trivyTimeout)
+		cmd := exec.CommandContext(dlCtx, m.trivyPath, "image", db.dlFlag, "--cache-dir", tmpDir)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			cancel()
+			slog.Error("trivydb: refresh download failed",
+				"db", db.logName, "error", err, "output", string(output))
+			return // don't partially update
+		}
+		cancel()
+	}
+
+	// Upload to S3 and swap into live dir
+	for _, db := range dbs {
+		if err := m.uploadDBFrom(ctx, db.s3Key, tmpDir, db.subDir, db.logName); err != nil {
+			slog.Error("trivydb: refresh upload failed", "db", db.logName, "error", err)
+			// continue anyway — swap the local copy even if S3 upload failed
+		}
+
+		// Swap: remove old, rename new into place
+		liveDir := filepath.Join(m.cacheDir, db.subDir)
+		tmpSubDir := filepath.Join(tmpDir, db.subDir)
+
+		if err := os.RemoveAll(liveDir); err != nil {
+			slog.Error("trivydb: refresh remove old dir failed", "db", db.logName, "error", err)
+			continue
+		}
+		if err := os.Rename(tmpSubDir, liveDir); err != nil {
+			slog.Error("trivydb: refresh swap failed", "db", db.logName, "error", err)
+			continue
+		}
+	}
+
+	m.lastUpdate.Store(time.Now().Unix())
+	slog.Info("trivydb: hourly refresh complete", "duration", time.Since(start).Round(time.Millisecond))
+}
+
+// trivyDownload runs trivy with the given download flag against the manager's cache dir.
+func (m *Manager) trivyDownload(ctx context.Context, flag string) error {
+	dlCtx, cancel := context.WithTimeout(ctx, trivyTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(dlCtx, m.trivyPath, "image", flag, "--cache-dir", m.cacheDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", err, string(output))
+	}
+	return nil
+}
+
+// uploadDB tars and uploads a DB subdirectory from the manager's cache dir to S3.
+func (m *Manager) uploadDB(ctx context.Context, s3Key, subDir, logName string) {
+	if err := m.uploadDBFrom(ctx, s3Key, m.cacheDir, subDir, logName); err != nil {
+		slog.Warn("trivydb: upload to S3 failed", "db", logName, "error", err)
+	}
+}
+
+// uploadDBFrom tars and uploads a DB subdirectory from the given base dir to S3.
+func (m *Manager) uploadDBFrom(ctx context.Context, s3Key, baseDir, subDir, logName string) error {
+	srcDir := filepath.Join(baseDir, subDir)
+	data, err := tarDir(srcDir, subDir)
+	if err != nil {
+		return fmt.Errorf("tar %s: %w", logName, err)
+	}
+
+	_, err = m.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      &m.bucket,
+		Key:         &s3Key,
+		Body:        bytes.NewReader(data),
+		ContentType: ptr("application/gzip"),
+	})
+	if err != nil {
+		return fmt.Errorf("S3 put %s: %w", logName, err)
+	}
+
+	slog.Info("trivydb: uploaded to S3", "db", logName, "key", s3Key, "size", len(data))
+	return nil
+}
+
+// downloadFromS3 fetches a key from S3 and returns its contents.
+func (m *Manager) downloadFromS3(ctx context.Context, key string) ([]byte, error) {
+	out, err := m.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &m.bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		var nsk *types.NoSuchKey
+		var nf *types.NotFound
+		if errors.As(err, &nsk) || errors.As(err, &nf) {
+			return nil, fmt.Errorf("not found: %s", key)
+		}
+		return nil, err
+	}
+	defer out.Body.Close()
+	return io.ReadAll(out.Body)
+}
+
+// tarDir creates a tar.gz archive of srcDir. Files are stored with paths
+// relative to the parent, prefixed with prefix (e.g., "db/trivy.db").
+func tarDir(srcDir, prefix string) ([]byte, error) {
+	var buf bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
+	if err != nil {
+		return nil, err
+	}
+	tw := tar.NewWriter(gw)
+
+	err = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		// Build archive path: prefix/filename
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		archivePath := filepath.Join(prefix, rel)
+		if archivePath == prefix {
+			// Root directory entry
+			return tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeDir,
+				Name:     prefix + "/",
+				Mode:     0o755,
+				ModTime:  info.ModTime(),
+			})
+		}
+
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		header.Name = archivePath
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(tw, f)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// extractTar extracts a tar.gz archive into destDir.
+func extractTar(data []byte, destDir string) error {
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// Prevent path traversal
+		target := filepath.Join(destDir, filepath.Clean(header.Name))
+		if !isSubpath(destDir, target) {
+			return fmt.Errorf("tar entry %q escapes destination", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode)&0o755)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+		}
+	}
+	return nil
+}
+
+// isSubpath returns true if target is under base.
+func isSubpath(base, target string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	// Reject "..", "../foo", or any absolute path
+	if rel == ".." || filepath.IsAbs(rel) {
+		return false
+	}
+	if len(rel) >= 3 && rel[:3] == "../" {
+		return false
+	}
+	return true
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/trivydb/trivydb_test.go
+++ b/trivydb/trivydb_test.go
@@ -1,0 +1,241 @@
+package trivydb
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// mockS3 implements s3API backed by an in-memory map.
+type mockS3 struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+}
+
+func newMockS3() *mockS3 {
+	return &mockS3{objects: make(map[string][]byte)}
+}
+
+func (m *mockS3) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	data, err := io.ReadAll(input.Body)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.objects[*input.Key] = data
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (m *mockS3) GetObject(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, ok := m.objects[*input.Key]
+	if !ok {
+		return nil, &types.NoSuchKey{}
+	}
+	return &s3.GetObjectOutput{
+		Body: io.NopCloser(bytes.NewReader(data)),
+	}, nil
+}
+
+func (m *mockS3) has(key string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.objects[key]
+	return ok
+}
+
+func TestTarExtractRoundTrip(t *testing.T) {
+	// Create a source directory with files
+	srcRoot := t.TempDir()
+	subDir := filepath.Join(srcRoot, "db")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "trivy.db"), []byte("fake-db-content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "metadata.json"), []byte(`{"Version":2}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tar it
+	data, err := tarDir(subDir, "db")
+	if err != nil {
+		t.Fatalf("tarDir: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("tarDir produced empty archive")
+	}
+
+	// Extract to a new directory
+	destRoot := t.TempDir()
+	if err := extractTar(data, destRoot); err != nil {
+		t.Fatalf("extractTar: %v", err)
+	}
+
+	// Verify files exist with correct content
+	got, err := os.ReadFile(filepath.Join(destRoot, "db", "trivy.db"))
+	if err != nil {
+		t.Fatalf("read extracted trivy.db: %v", err)
+	}
+	if string(got) != "fake-db-content" {
+		t.Errorf("trivy.db content = %q, want %q", got, "fake-db-content")
+	}
+
+	got, err = os.ReadFile(filepath.Join(destRoot, "db", "metadata.json"))
+	if err != nil {
+		t.Fatalf("read extracted metadata.json: %v", err)
+	}
+	if string(got) != `{"Version":2}` {
+		t.Errorf("metadata.json content = %q, want %q", got, `{"Version":2}`)
+	}
+}
+
+func TestExtractTarPathTraversal(t *testing.T) {
+	// Build a tar.gz with a path-traversal entry manually
+	var buf bytes.Buffer
+	if err := writeMaliciousTar(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := t.TempDir()
+	err := extractTar(buf.Bytes(), dest)
+	if err == nil {
+		t.Fatal("expected error for path traversal, got nil")
+	}
+}
+
+func TestUploadDBFrom(t *testing.T) {
+	mock := newMockS3()
+	cacheDir := t.TempDir()
+
+	// Create a fake DB directory
+	dbDir := filepath.Join(cacheDir, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "trivy.db"), []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newWithClient(mock, "test-bucket", cacheDir, "/fake/trivy")
+
+	err := mgr.uploadDBFrom(context.Background(), vulnDBKey, cacheDir, "db", "vuln-db")
+	if err != nil {
+		t.Fatalf("uploadDBFrom: %v", err)
+	}
+
+	if !mock.has(vulnDBKey) {
+		t.Error("expected vuln-db key in S3 after upload")
+	}
+}
+
+func TestDownloadFromS3NotFound(t *testing.T) {
+	mock := newMockS3()
+	mgr := newWithClient(mock, "test-bucket", t.TempDir(), "/fake/trivy")
+
+	_, err := mgr.downloadFromS3(context.Background(), "nonexistent-key")
+	if err == nil {
+		t.Fatal("expected error for missing key, got nil")
+	}
+}
+
+func TestUploadAndRestoreRoundTrip(t *testing.T) {
+	mock := newMockS3()
+
+	// Create source with DB files and upload
+	srcDir := t.TempDir()
+	dbDir := filepath.Join(srcDir, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "trivy.db"), []byte("roundtrip-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcMgr := newWithClient(mock, "test-bucket", srcDir, "/fake/trivy")
+	if err := srcMgr.uploadDBFrom(context.Background(), vulnDBKey, srcDir, "db", "vuln-db"); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	// Download to a new location and extract
+	destDir := t.TempDir()
+	destMgr := newWithClient(mock, "test-bucket", destDir, "/fake/trivy")
+	data, err := destMgr.downloadFromS3(context.Background(), vulnDBKey)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if err := extractTar(data, destDir); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(destDir, "db", "trivy.db"))
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(got) != "roundtrip-data" {
+		t.Errorf("restored content = %q, want %q", got, "roundtrip-data")
+	}
+}
+
+func TestIsSubpath(t *testing.T) {
+	tests := []struct {
+		base, target string
+		want         bool
+	}{
+		{"/a/b", "/a/b/c", true},
+		{"/a/b", "/a/b/c/d", true},
+		{"/a/b", "/a/c", false},
+		{"/a/b", "/a", false},
+	}
+	for _, tt := range tests {
+		got := isSubpath(tt.base, tt.target)
+		if got != tt.want {
+			t.Errorf("isSubpath(%q, %q) = %v, want %v", tt.base, tt.target, got, tt.want)
+		}
+	}
+}
+
+func TestManagerReadyAndDBAge(t *testing.T) {
+	mgr := newWithClient(newMockS3(), "bucket", t.TempDir(), "/fake/trivy")
+
+	if mgr.Ready() {
+		t.Error("expected Ready()=false before Start")
+	}
+	if mgr.DBAge() != 0 {
+		t.Errorf("expected DBAge()=0 before Start, got %v", mgr.DBAge())
+	}
+}
+
+// writeMaliciousTar creates a tar.gz with a "../escape" path entry.
+func writeMaliciousTar(w *bytes.Buffer) error {
+	gw := gzip.NewWriter(w)
+	tw := tar.NewWriter(gw)
+
+	header := &tar.Header{
+		Name: "../../../etc/evil",
+		Mode: 0o644,
+		Size: 4,
+	}
+	if err := tw.WriteHeader(header); err != nil {
+		return err
+	}
+	if _, err := tw.Write([]byte("evil")); err != nil {
+		return err
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gw.Close()
+}


### PR DESCRIPTION
## Summary

- Adds `trivydb` package that caches Trivy's vulnerability DB and Java DB in the existing S3 bucket, reducing cold start DB restore from ~30-60s (upstream download) to ~4-14s (S3 fetch)
- Background goroutine refreshes both DBs hourly (non-blocking: downloads to temp dir, uploads to S3, then swaps into live cache)
- Only keeps one copy per DB in S3 — `PutObject` overwrites atomically, no stale copies accumulate
- Scanner gains `ScanOption` functional options for both `ScanImage` and `ScanImageStream`: `WithCacheDir`, `WithSkipDBUpdate`, `WithSkipJavaDBUpdate`
- Docker-compose uses named volume for `/tmp` (Trivy DB is ~700MB uncompressed, exceeds tmpfs limits)
- Feature is gated on `CACHE_S3_BUCKET` — no new env vars, works with existing MinIO/Tigris/S3 setup

## How it works

1. **Startup**: restore `trivy-db/vuln-db.tar.gz` and `trivy-db/java-db.tar.gz` from S3 → extract to Trivy cache dir. On S3 miss (first deploy), download from upstream and upload for next time.
2. **Scans**: pass `--skip-db-update`, `--skip-java-db-update`, `--cache-dir` to Trivy CLI.
3. **Hourly**: download fresh DBs to temp dir, tar+gzip, upload to S3, swap into live dir via `os.Rename`.
4. **Graceful degradation**: S3 failures → fall through to upstream. No `CACHE_S3_BUCKET` → feature disabled entirely.

## Verified locally with docker-compose + MinIO

| Operation | 1st request | 2nd request (cached) |
|---|---|---|
| Inspect alpine | 8.2s | cache hit, 2ms S3 latency |
| Scan alpine | 2.6s | 0.4s (cache hit) |
| Scan oci-explorer | 5.2s | — |
| DB startup (S3 miss) | vuln: 8s, java: 52s | — |
| DB startup (S3 restore) | vuln: 4s, java: 14s | — |

## Test plan

- [x] `go build ./...` passes
- [x] All unit tests pass (48 passing, 9 skipped due to Docker Hub rate limits)
- [x] 7 new unit tests for trivydb: tar/extract round-trip, path traversal protection, S3 upload/download/restore, Manager state
- [x] Docker-compose + MinIO end-to-end: DB download, S3 upload, restart restore, inspect cache, scan cache — all verified
- [x] Rebased on main — includes streaming scan support, URL query params, and all recent fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)